### PR TITLE
aspect: add APIs for directly logging events

### DIFF
--- a/src/python/perfflowaspect/advice_dispatch.py
+++ b/src/python/perfflowaspect/advice_dispatch.py
@@ -37,6 +37,9 @@ class AdviceDispatcher:
         clobj = AdviceDispatcher.advice_dict[key]
         return AdviceDispatcher._dispatch(clobj, pointcut, scope)
 
+    def get_advice(key):
+        return AdviceDispatcher.advice_dict[key]
+
 
 #
 # vi: ts=4 sw=4 expandtab

--- a/src/python/perfflowaspect/aspect.py
+++ b/src/python/perfflowaspect/aspect.py
@@ -32,6 +32,13 @@ def critical_path(pointcut="around", scope=""):
 
     return decorator_critical_path
 
+def sync_event(pointcut, name, category):
+    clobj = AdviceDispatcher.get_advice(advice_kind)
+    clobj.sync_event(pointcut, name, category)
+
+def async_event(pointcut, name, category, scope=None, id=None):
+    clobj = AdviceDispatcher.get_advice(advice_kind)
+    clobj.async_event(pointcut, name, category, scope=scope, id=id)
 
 #
 # vi: ts=4 sw=4 expandtab

--- a/src/python/tests/smoketest_direct.py
+++ b/src/python/tests/smoketest_direct.py
@@ -1,0 +1,23 @@
+#! /usr/bin/python3
+
+import time
+import os.path
+from perfflowaspect import aspect
+
+
+def foo():
+    aspect.sync_event("before", "foo", filename)
+    time.sleep(2)
+    print("hello")
+    aspect.sync_event("after", "foo", filename)
+
+
+def main():
+    aspect.sync_event("before", "main", filename)
+    foo()
+    aspect.sync_event("after", "main", filename)
+
+
+if __name__ == "__main__":
+    filename = os.path.basename(__file__)
+    main()

--- a/src/python/tests/smoketest_future_direct.py
+++ b/src/python/tests/smoketest_future_direct.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+
+import os.path
+import time
+import logging
+import threading
+from perfflowaspect import aspect
+
+from concurrent.futures import ThreadPoolExecutor
+from time import sleep
+
+pool = ThreadPoolExecutor(3)
+
+
+def bar(message):
+    aspect.async_event("before", "bar", filename)
+    sleep(3)
+    aspect.async_event("after", "bar", filename)
+    return message
+
+
+def foo():
+    aspect.sync_event("before", "foo", filename)
+    time.sleep(2)
+    future = pool.submit(bar, ("hello"))
+    while not future.done():
+        sleep(1)
+    print(future.done())
+    print(future.result())
+    aspect.sync_event("after", "foo", filename)
+
+
+def main():
+    foo()
+
+
+if __name__ == "__main__":
+    filename = os.path.basename(__file__)
+    main()


### PR DESCRIPTION
Problem: For Maestro and GMD, it is sometimes more ergonomoic to insert
function calls that directly log events as opposed to using the decorators.

Solution: add two methods (create_[a]sync_event) that enable direct logging of
events.

Closes #16