### PR TITLE
Fix build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 are not yet stable.* The github issue tracker is the primary way to
 communicate with the developers.
 
-[![Build Status](https://github.com/flux-framework/PerfFlowAspect/actions/workflows/github-actions.yaml/badge.svg)](https://github.com/flux-framework/PerfFlowAspect/actions)
+[![Build Status](https://github.com/flux-framework/PerfFlowAspect/actions/workflows/github-actions.yml/badge.svg)](https://github.com/flux-framework/PerfFlowAspect/actions)
 
 ## PerfFlowAspect: a tool to analyze cross-cutting performance concerns of composite scientific workflows.
 


### PR DESCRIPTION
Edits path to github actions workflow yaml file so badge shows correctly in README