### PR TITLE
setup.py: remove package_dir field

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -64,7 +64,8 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip pytest setuptools
-          python src/python/setup.py install
+          cd src/python
+          python setup.py install
           python -m pip list
 
       - name: Run Python Smoke Tests

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -32,9 +32,6 @@ setup(
     version="0.0.1",
     author="Dong H. Ahn, Stephen Herbein, James Corbett, Francesco Di Natale",
     author_email="ahn1@llnl.gov, herbein1@llnl.gov, corbett8@llnl.gov, dinatale3@llnl.gov",
-    package_dir = {
-        '': 'src/python'
-        },
     packages=['perfflowaspect'],
     entry_points={},
     install_requires=[],


### PR DESCRIPTION
package_dir is no longer needed since modules are at the root, update CI workflow to install package from where setup.py is located.

Addresses part of #15, still uncertain about installing into `dist-packages` vs `site-packages`