### PR TITLE
Use qualified name in logging performance event data

### DIFF
--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -214,7 +214,7 @@ class ChromeTracingAdvice:
 
     @classmethod
     def __create_event_from_func(cls, func):
-        return cls.__create_event(func.__name__, func.__module__)
+        return cls.__create_event(func.__qualname__, func.__module__)
 
     @staticmethod
     def __flush_log(s):


### PR DESCRIPTION
Transition from name to qualified name when logging performance event data
of the annotated function. The qualified name provides more fine-grained detail
particularly when it comes to annotating nested classes, methods, or functions.
With this change, we can distinguish event data from similarly-named functions
that may be in different classes.

Fixes #14 

Perfetto output using name:
<img width="500" alt="Screen Shot 2021-12-29 at 3 49 18 PM" src="https://user-images.githubusercontent.com/5253432/147711238-4899d02a-04b0-4e15-8e6d-92bb66420780.png">

Perfetto output using qualified name:
<img width="500" alt="Screen Shot 2021-12-29 at 3 48 46 PM" src="https://user-images.githubusercontent.com/5253432/147711244-7353238f-b636-45b4-ad58-76c5a7004ab0.png">