### PR TITLE
bump heading of license from level 4 to 3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ after the execution of the annotated function whereas
 either corresponding point of function execution.
 
 
-#### License
+### License
 
 SPDX-License-Identifier: LGPL-3.0
 


### PR DESCRIPTION
Moving license header to a heading level 3 to be consistent with existing headers