### PR TITLE
Enable/disable PerfFlow profiling at runtime

### DIFF
--- a/docs/QuickStart.rst
+++ b/docs/QuickStart.rst
@@ -63,3 +63,10 @@ Details on these can be found at the links below:
 
 - **Chrome Tracing Tool:** https://www.chromium.org/developers/how-tos/trace-event-profiling-tool/
 - **Perfetto Visualizer:** https://perfetto.dev/
+
+To disable all PerfFlowAspect annotations, set the
+``PERFFLOW_OPTIONS="log-enable="`` to ``False`` at runtime.
+
+.. code:: bash
+
+    PERFFLOW_OPTIONS="log-enable=False" ./test/smoketest.py

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -162,6 +162,9 @@ int advice_chrome_tracing_t::cannonicalize_perfflow_options ()
     if (m_perfflow_options.find ("log-dir") == m_perfflow_options.end ()) {
         m_perfflow_options["log-dir"] = "./";
     }
+    if (m_perfflow_options.find ("log-enable") == m_perfflow_options.end ()) {
+        m_perfflow_options["log-enable"] = "True";
+    }
     return 0;
 }
 
@@ -305,6 +308,8 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
     //             pid: process id
     // To change the directory in which the log file is created
     //     PERFFLOW_OPTIONS="log-dir=DIR"
+    // To disable logging (default: log-enable=True)
+    //     PERFFLOW_OPTIONS="log-enable=False"
     // You can combine the options in colon (:) delimited format
 
     if (parse_perfflow_options () < 0)
@@ -352,6 +357,19 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
                                  std::system_category (),
                                  "log-dir creation failed");
     m_fn = log_dir + "/" + m_fn;
+
+    std::string log_enable = m_perfflow_options["log-enable"];
+    if (log_enable == "True") {
+        m_enable_logging = 1;
+    }
+    else if (log_enable == "False" || log_enable == "false" || log_enable == "FALSE") {
+        m_enable_logging = 0;
+    }
+    else {
+        throw std::system_error (errno,
+                                 std::system_category (),
+                                 "invalid log-enable value");
+    }
 
     m_before_counter_mutex = PTHREAD_MUTEX_INITIALIZER;
     m_after_counter_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -52,6 +52,7 @@ private:
     std::ostringstream m_oss;
     std::ofstream m_ofs;
     std::string m_fn = "";
+    int m_enable_logging = 0;
     int m_before_counter = 0;
     int m_after_counter = 0;
     pthread_mutex_t m_before_counter_mutex;

--- a/src/c/test/t0001-cbinding-basic.t
+++ b/src/c/test/t0001-cbinding-basic.t
@@ -140,4 +140,26 @@ PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
     rm perfflow.{fffffff.444444.123456}.pfw
 '
 
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest' '
+    PERFFLOW_OPTIONS="log-enable=False" ../smoketest &&
+    ! test -f perfflow.$(hostname).[0-9]*.pfw
+    if test -f perfflow.$(hostname).[0-9]*.pfw; then
+        rm perfflow.$(hostname).[0-9]*.pfw
+    fi
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest' '
+    PERFFLOW_OPTIONS="log-enable=True" ../smoketest &&
+    test -f perfflow.$(hostname).[0-9]*.pfw &&
+    rm perfflow.$(hostname).[0-9]*.pfw
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest2' '
+    PERFFLOW_OPTIONS="log-enable=False" ../smoketest2 &&
+    ! test -f perfflow.$(hostname).[0-9]*.pfw
+    if test -f perfflow.$(hostname).[0-9]*.pfw; then
+        rm perfflow.$(hostname).[0-9]*.pfw
+    fi
+'
+
 test_done

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -120,7 +120,7 @@ class ChromeTracingAdvice:
     # PERFFLOW_OPTIONS envVar
     # To specify the name of this workflow component (default: name=generic)
     #     PERFFLOW_OPTIONS="name=foo"
-    # To constomize output filename (default: log-filename-include=hostname,pid)
+    # To customize output filename (default: log-filename-include=hostname,pid)
     #     PERFFLOW_OPTIONS="log-filename-include=<metadata1, metadata2, ...>
     #         Supported metadata:
     #             name: workflow component name

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -38,6 +38,8 @@ def cannonicalize_perfflow_options():
         perfflow_options["log-filename-include"] = "hostname,pid"
     if perfflow_options.get("log-dir") is None:
         perfflow_options["log-dir"] = "./"
+    if perfflow_options.get("log-enable") is None:
+        perfflow_options["log-enable"] = "True"
 
 
 def parse_perfflow_options():
@@ -129,6 +131,8 @@ class ChromeTracingAdvice:
     #             pid: process id
     # To change the directory in which the log file is created
     #     PERFFLOW_OPTIONS="log-dir=DIR"
+    # To disable logging (default: log-enable=True)
+    #     PERFFLOW_OPTIONS="log-enable=False"
     # You can combine the options in colon (:) delimited format
 
     parse_perfflow_options()
@@ -156,6 +160,14 @@ class ChromeTracingAdvice:
     if log_dir is not None:
         os.makedirs(log_dir, exist_ok=True)
         fn = os.path.join(log_dir, fn)
+
+    log_enable = perfflow_options["log-enable"]
+    if log_enable in ["True", "true", "TRUE"]:
+        enable_logging = True
+    elif log_enable in ["False", "false", "FALSE"]:
+        enable_logging = False
+    else:
+        raise ValueError("perfflow invalid option: log-enable=[True|False]")
 
     logger = None
 

--- a/src/python/perfflowaspect/advice_dispatch.py
+++ b/src/python/perfflowaspect/advice_dispatch.py
@@ -12,19 +12,6 @@ import sys
 from .advice_chrome import ChromeTracingAdvice
 
 
-def _disable(func):
-    "Do nothing decorator (e.g., disables func)"
-
-    def do_nothing_func(*args, **kargs):
-        print(
-            "perfflow warning: logging has been disabled for {}".format(func.__name__),
-            file=sys.stderr,
-        )
-        pass
-
-    return do_nothing_func
-
-
 class AdviceDispatcher:
 
     # Note that you need to extend advice_dict When you add
@@ -34,27 +21,17 @@ class AdviceDispatcher:
 
     def _dispatch(clobj, pointcut, scope):
         if pointcut == "around":
-            return clobj.around if ChromeTracingAdvice.enable_logging else _disable
+            return clobj.around
         elif pointcut == "before":
-            return clobj.before if ChromeTracingAdvice.enable_logging else _disable
+            return clobj.before
         elif pointcut == "after":
-            return clobj.after if ChromeTracingAdvice.enable_logging else _disable
+            return clobj.after
         elif pointcut == "around_async":
-            return (
-                clobj.around_async if ChromeTracingAdvice.enable_logging else _disable
-            )
+            return clobj.around_async
         elif pointcut == "before_async":
-            return (
-                clobj.before_async(scope)
-                if ChromeTracingAdvice.enable_logging
-                else _disable
-            )
+            return clobj.before_async(scope)
         elif pointcut == "after_async":
-            return (
-                clobj.after_async(scope)
-                if ChromeTracingAdvice.enable_logging
-                else _disable
-            )
+            return clobj.after_async(scope)
         raise KeyError("unknown pointcut", pointcut)
 
     def get(key, pointcut, scope):

--- a/src/python/perfflowaspect/advice_dispatch.py
+++ b/src/python/perfflowaspect/advice_dispatch.py
@@ -8,7 +8,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import sys
 from .advice_chrome import ChromeTracingAdvice
 
 

--- a/src/python/perfflowaspect/advice_dispatch.py
+++ b/src/python/perfflowaspect/advice_dispatch.py
@@ -8,7 +8,16 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
+import sys
 from .advice_chrome import ChromeTracingAdvice
+
+
+def _disable(func):
+    "Do nothing decorator (e.g., disables func)"
+    def do_nothing_func(*args, **kargs):
+        print("perfflow warning: logging has been disabled for {}".format(func.__name__), file=sys.stderr)
+        pass
+    return do_nothing_func
 
 
 class AdviceDispatcher:
@@ -20,17 +29,17 @@ class AdviceDispatcher:
 
     def _dispatch(clobj, pointcut, scope):
         if pointcut == "around":
-            return clobj.around
+            return clobj.around if ChromeTracingAdvice.enable_logging else _disable
         elif pointcut == "before":
-            return clobj.before
+            return clobj.before if ChromeTracingAdvice.enable_logging else _disable
         elif pointcut == "after":
-            return clobj.after
+            return clobj.after if ChromeTracingAdvice.enable_logging else _disable
         elif pointcut == "around_async":
-            return clobj.around_async
+            return clobj.around_async if ChromeTracingAdvice.enable_logging else _disable
         elif pointcut == "before_async":
-            return clobj.before_async(scope)
+            return clobj.before_async(scope) if ChromeTracingAdvice.enable_logging else _disable
         elif pointcut == "after_async":
-            return clobj.after_async(scope)
+            return clobj.after_async(scope) if ChromeTracingAdvice.enable_logging else _disable
         raise KeyError("unknown pointcut", pointcut)
 
     def get(key, pointcut, scope):

--- a/src/python/perfflowaspect/advice_dispatch.py
+++ b/src/python/perfflowaspect/advice_dispatch.py
@@ -14,9 +14,14 @@ from .advice_chrome import ChromeTracingAdvice
 
 def _disable(func):
     "Do nothing decorator (e.g., disables func)"
+
     def do_nothing_func(*args, **kargs):
-        print("perfflow warning: logging has been disabled for {}".format(func.__name__), file=sys.stderr)
+        print(
+            "perfflow warning: logging has been disabled for {}".format(func.__name__),
+            file=sys.stderr,
+        )
         pass
+
     return do_nothing_func
 
 
@@ -35,11 +40,21 @@ class AdviceDispatcher:
         elif pointcut == "after":
             return clobj.after if ChromeTracingAdvice.enable_logging else _disable
         elif pointcut == "around_async":
-            return clobj.around_async if ChromeTracingAdvice.enable_logging else _disable
+            return (
+                clobj.around_async if ChromeTracingAdvice.enable_logging else _disable
+            )
         elif pointcut == "before_async":
-            return clobj.before_async(scope) if ChromeTracingAdvice.enable_logging else _disable
+            return (
+                clobj.before_async(scope)
+                if ChromeTracingAdvice.enable_logging
+                else _disable
+            )
         elif pointcut == "after_async":
-            return clobj.after_async(scope) if ChromeTracingAdvice.enable_logging else _disable
+            return (
+                clobj.after_async(scope)
+                if ChromeTracingAdvice.enable_logging
+                else _disable
+            )
         raise KeyError("unknown pointcut", pointcut)
 
     def get(key, pointcut, scope):

--- a/src/python/perfflowaspect/aspect.py
+++ b/src/python/perfflowaspect/aspect.py
@@ -21,16 +21,8 @@ def _disable(func):
     "Do nothing decorator (e.g., disables func)"
 
     def do_nothing_func(*args, **kargs):
-        print(
-            "perfflow warning: logging has been disabled for {}".format(func.__name__),
-            file=sys.stderr,
-        )
         pass
 
-    print(
-        "perfflow warning: logging has been disabled for {}".format(func),
-        file=sys.stderr,
-    )
     return do_nothing_func
 
 

--- a/src/python/perfflowaspect/aspect.py
+++ b/src/python/perfflowaspect/aspect.py
@@ -10,7 +10,6 @@
 
 import sys
 import functools
-import inspect
 from .advice_dispatch import AdviceDispatcher
 from .advice_chrome import ChromeTracingAdvice
 

--- a/src/python/test/t0001-pybinding-basic.t
+++ b/src/python/test/t0001-pybinding-basic.t
@@ -137,12 +137,12 @@ PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
     rm perfflow.{fffffff.444444.123456}.pfw
 '
 
-test_expect_success 'PERFFLOW_OPTIONS: disable logging' '
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest.py &&
     ! test -f perfflow.$(hostname).[0-9]*.pfw
 '
 
-test_expect_success 'PERFFLOW_OPTIONS: enable logging' '
+test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest' '
     PERFFLOW_OPTIONS="log-enable=True" ../smoketest.py &&
     test -f perfflow.$(hostname).[0-9]*.pfw &&
     rm perfflow.$(hostname).[0-9]*.pfw

--- a/src/python/test/t0001-pybinding-basic.t
+++ b/src/python/test/t0001-pybinding-basic.t
@@ -139,7 +139,7 @@ PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest.py &&
-    ! -f perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: enable logging' '
@@ -148,19 +148,30 @@ test_expect_success 'PERFFLOW_OPTIONS: enable logging' '
     rm perfflow.$(hostname).[0-9]*.pfw
 '
 
-test_expect_success 'PERFFLOW_OPTIONS: disable logging smoktest_future' '
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_future' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future.py &&
-    ! -f perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.$(hostname).[0-9]*.pfw
 '
 
-test_expect_success 'PERFFLOW_OPTIONS: disable logging smoktest_future2' '
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_future2' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future2.py &&
-    ! -f perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.$(hostname).[0-9]*.pfw
 '
 
-test_expect_success 'PERFFLOW_OPTIONS: disable logging smoktest_future_direct' '
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_direct' '
+    PERFFLOW_OPTIONS="log-enable=False" ../smoketest_direct.py &&
+    ! test -f perfflow.$(hostname).[0-9]*.pfw
+    if test -f perfflow.$(hostname).[0-9]*.pfw; then
+        rm perfflow.$(hostname).[0-9]*.pfw
+    fi
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_future_direct' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future_direct.py &&
-    ! -f perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.$(hostname).[0-9]*.pfw
+    if test -f perfflow.$(hostname).[0-9]*.pfw; then
+        rm perfflow.$(hostname).[0-9]*.pfw
+    fi
 '
 
 test_done

--- a/src/python/test/t0001-pybinding-basic.t
+++ b/src/python/test/t0001-pybinding-basic.t
@@ -137,4 +137,30 @@ PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
     rm perfflow.{fffffff.444444.123456}.pfw
 '
 
+test_expect_success 'PERFFLOW_OPTIONS: disable logging' '
+    PERFFLOW_OPTIONS="log-enable=False" ../smoketest.py &&
+    ! -f perfflow.$(hostname).[0-9]*.pfw
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: enable logging' '
+    PERFFLOW_OPTIONS="log-enable=True" ../smoketest.py &&
+    test -f perfflow.$(hostname).[0-9]*.pfw &&
+    rm perfflow.$(hostname).[0-9]*.pfw
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoktest_future' '
+    PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future.py &&
+    ! -f perfflow.$(hostname).[0-9]*.pfw
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoktest_future2' '
+    PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future2.py &&
+    ! -f perfflow.$(hostname).[0-9]*.pfw
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: disable logging smoktest_future_direct' '
+    PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future_direct.py &&
+    ! -f perfflow.$(hostname).[0-9]*.pfw
+'
+
 test_done

--- a/src/python/test/t0001-pybinding-basic.t
+++ b/src/python/test/t0001-pybinding-basic.t
@@ -140,6 +140,9 @@ PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest.py &&
     ! test -f perfflow.$(hostname).[0-9]*.pfw
+    if test -f perfflow.$(hostname).[0-9]*.pfw; then
+        rm perfflow.$(hostname).[0-9]*.pfw
+    fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest' '
@@ -151,11 +154,17 @@ test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest' '
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_future' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future.py &&
     ! test -f perfflow.$(hostname).[0-9]*.pfw
+    if test -f perfflow.$(hostname).[0-9]*.pfw; then
+        rm perfflow.$(hostname).[0-9]*.pfw
+    fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_future2' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future2.py &&
     ! test -f perfflow.$(hostname).[0-9]*.pfw
+    if test -f perfflow.$(hostname).[0-9]*.pfw; then
+        rm perfflow.$(hostname).[0-9]*.pfw
+    fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_direct' '


### PR DESCRIPTION
Adds `log-enable=` to `PERFFLOW_OPTIONS` to enable/disable profiling at runtime. By default, profiling is on. When disabled, PerfFlow calls an empty decorator (for python annotations).

Fixes #3 

- [x] Add unit tests for Python
- [x] Add unit tests for C
- [x] Add log-enable option for Python
- [x] Add log-enable option for C