### PR TITLE
update python header to use /usr/bin/env

### DIFF
--- a/src/python/test/smoketest.py
+++ b/src/python/test/smoketest.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python
 
 import time
 import perfflowaspect

--- a/src/python/test/smoketest_MT.py
+++ b/src/python/test/smoketest_MT.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python
 
 import time
 import threading

--- a/src/python/test/smoketest_direct.py
+++ b/src/python/test/smoketest_direct.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python
 
 import time
 import os.path

--- a/src/python/test/smoketest_future.py
+++ b/src/python/test/smoketest_future.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import time
 import perfflowaspect

--- a/src/python/test/smoketest_future2.py
+++ b/src/python/test/smoketest_future2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import time
 import perfflowaspect

--- a/src/python/test/smoketest_future_direct.py
+++ b/src/python/test/smoketest_future_direct.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import os.path
 import time

--- a/src/python/test/smoketest_future_incorrect.py
+++ b/src/python/test/smoketest_future_incorrect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import time
 import perfflowaspect


### PR DESCRIPTION
Python header was pointing at /usr/bin/python, which was the same across python versions in CI. In this PR, we update the header to use the system environment python, which changes across CI tests.