### PR TITLE
CPU and Memory usage in C

### DIFF
--- a/src/c/runtime/advice_base.hpp
+++ b/src/c/runtime/advice_base.hpp
@@ -16,10 +16,12 @@ struct advice_base_t
     virtual ~advice_base_t () {}
     virtual int before (const char *module,
                         const char *function,
-                        const char *flow) = 0;
+                        const char *flow,
+                        const char *pcut) = 0;
     virtual int after (const char *module,
                        const char *function,
-                       const char *flow) = 0;
+                       const char *flow,
+                       const char *pcut) = 0;
     virtual int before_async (const char *module,
                               const char *function,
                               const char *scope,

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -499,7 +499,7 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
 
     std::string usage_enable = m_perfflow_options["cpu_mem_usage"];
     if (usage_enable == "False" || usage_enable == "false" ||
-             usage_enable == "FALSE"))
+             usage_enable == "FALSE")
     {
         m_usage_enable = 0;
     }

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -174,20 +174,6 @@ int advice_chrome_tracing_t::encode_event(json_t *o, const char *ph,
             goto json_memerror;
         }
     }
-    if (std::string("C") == ph)
-    {
-        json_t *cpu_usage_o, *mem_usage_o;
-        if (!(cpu_usage_o = json_real(cpu_usage)))
-            goto json_memerror;
-        if (json_object_set_new(args_o, "cpu_usage", cpu_usage_o) < 0)
-            goto json_memerror;
-        if (!(mem_usage_o = json_integer(static_cast<json_int_t>(mem_usage))))
-            goto json_memerror;
-        if (json_object_set_new(args_o, "memory_usage", mem_usage_o) < 0)
-            goto json_memerror;
-        if (json_object_set_new(o, "args", args_o) < 0)
-            goto json_memerror;
-    }
     return 0;
 
 json_memerror:

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -498,7 +498,8 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
     }
 
     std::string usage_enable = m_perfflow_options["cpu_mem_usage"];
-    if (usage_enable == "False")
+    if (usage_enable == "False" || usage_enable == "false" ||
+             usage_enable == "FALSE"))
     {
         m_usage_enable = 0;
     }

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -499,7 +499,7 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
 
     std::string usage_enable = m_perfflow_options["cpu_mem_usage"];
     if (usage_enable == "False" || usage_enable == "false" ||
-             usage_enable == "FALSE")
+        usage_enable == "FALSE")
     {
         m_usage_enable = 0;
     }

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -397,20 +397,6 @@ int advice_chrome_tracing_t::set_perfflow_instance_path(
     return setenv("PERFFLOW_INSTANCE_PATH", path.c_str(), 1);
 }
 
-int advice_chrome_tracing_t::set_metrics_var(const std::string value)
-{
-    return setenv("CPU_MEM_USAGE", value.c_str(), 1);
-}
-
-const std::string advice_chrome_tracing_t::get_metrics_var()
-{
-    if (NULL == getenv("CPU_MEM_USAGE"))
-    {
-        return "False";
-    }
-    return getenv("CPU_MEM_USAGE");
-}
-
 
 /******************************************************************************
  *                                                                            *
@@ -445,23 +431,6 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
     if (set_perfflow_instance_path(inst_path))
         throw std::system_error(errno, std::system_category(),
                                 "set_perfflow_instance_path");
-
-    metric_var = get_metrics_var();
-    if (metric_var == "True" || metric_var == "true" || metric_var == "TRUE")
-    {
-        metric_var = "True";
-    }
-    else if (metric_var == "False" || metric_var == "false" ||
-             metric_var == "FALSE")
-    {
-        metric_var = "False";
-    }
-    else
-    {
-        metric_var = "False";
-        if (set_metrics_var("False"))
-            throw std::system_error(errno, std::system_category(), "set_metrics_var");
-    }
 
     std::string include = m_perfflow_options["log-filename-include"];
     std::vector<std::string> include_list;

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -22,6 +22,7 @@
 #include <openssl/sha.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/resource.h>
 
 // TODO: only works for Linux
 #define my_gettid() ((pid_t)syscall(SYS_gettid))
@@ -48,18 +49,21 @@ int advice_chrome_tracing_t::get_timestamp(double &tstamp)
 
 int advice_chrome_tracing_t::create_event(json_t **o,
         const char *module,
-        const char *function)
+        const char *function,
+        double &ts)
 {
     int rc, status;
     char *cxa;
-    double ts;
     json_t *json;
     pid_t pid, tid;
     std::string demangle;
 
-    if ((rc = get_timestamp(ts)) < 0)
+    if (ts == 0)
     {
-        return rc;
+        if ((rc = get_timestamp(ts)) < 0)
+        {
+            return rc;
+        }
     }
 
     pid = getpid();
@@ -90,8 +94,11 @@ int advice_chrome_tracing_t::create_event(json_t **o,
 
 int advice_chrome_tracing_t::encode_event(json_t *o, const char *ph,
         const char *scope,
-        const char *flow_enclose, int64_t id)
+        const char *flow_enclose, int64_t id,
+        double cpu_usage, long mem_usage)
 {
+    char *temp;
+    json_t *args_o = json_object();
     if (!o || !ph)
     {
         errno = EINVAL;
@@ -142,6 +149,20 @@ int advice_chrome_tracing_t::encode_event(json_t *o, const char *ph,
         {
             goto json_memerror;
         }
+    }
+    if (std::string("C") == ph)
+    {
+        json_t *cpu_usage_o, *mem_usage_o;
+        if (!(cpu_usage_o = json_real(cpu_usage)))
+            goto json_memerror;
+        if (json_object_set_new(args_o, "cpu_usage", cpu_usage_o) < 0)
+            goto json_memerror;
+        if (!(mem_usage_o = json_integer(static_cast<json_int_t>(mem_usage))))
+            goto json_memerror;
+        if (json_object_set_new(args_o, "memory_usage", mem_usage_o) < 0)
+            goto json_memerror;
+        if (json_object_set_new(o, "args", args_o) < 0)
+            goto json_memerror;
     }
     return 0;
 
@@ -362,6 +383,20 @@ int advice_chrome_tracing_t::set_perfflow_instance_path(
     return setenv("PERFFLOW_INSTANCE_PATH", path.c_str(), 1);
 }
 
+int advice_chrome_tracing_t::set_metrics_var(const std::string value)
+{
+    return setenv("CPU_MEM_USAGE", value.c_str(), 1);
+}
+
+const std::string advice_chrome_tracing_t::get_metrics_var()
+{
+    if (NULL == getenv("CPU_MEM_USAGE"))
+    {
+        return "False";
+    }
+    return getenv("CPU_MEM_USAGE");
+}
+
 
 /******************************************************************************
  *                                                                            *
@@ -396,6 +431,23 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
     if (set_perfflow_instance_path(inst_path))
         throw std::system_error(errno, std::system_category(),
                                 "set_perfflow_instance_path");
+
+    metric_var = get_metrics_var();
+    if (metric_var == "True" || metric_var == "true" || metric_var == "TRUE")
+    {
+        metric_var = "True";
+    }
+    else if (metric_var == "False" || metric_var == "false" ||
+             metric_var == "FALSE")
+    {
+        metric_var = "False";
+    }
+    else
+    {
+        metric_var = "False";
+        if (set_metrics_var("False"))
+            throw std::system_error(errno, std::system_category(), "set_metrics_var");
+    }
 
     std::string include = m_perfflow_options["log-filename-include"];
     std::vector<std::string> include_list;
@@ -491,6 +543,38 @@ int advice_chrome_tracing_t::write_to_sstream(const char *str)
     return rc;
 }
 
+double advice_chrome_tracing_t::get_wall_time()
+{
+    struct timeval start;
+    double time_d;
+    if (gettimeofday(&start, NULL))
+    {
+        return 0;
+    }
+    time_d = (double)start.tv_sec + (double)start.tv_usec * .000001;
+    return time_d;
+}
+
+double advice_chrome_tracing_t::get_cpu_time()
+{
+    struct rusage usage;
+    struct timeval time_u;
+    double time_d;
+    getrusage(RUSAGE_SELF, &usage);
+    time_u = usage.ru_utime;
+    time_d = (double) time_u.tv_sec + (double) time_u.tv_usec / 1000000;
+    return time_d;
+}
+
+long advice_chrome_tracing_t::get_memory_usage()
+{
+    struct rusage usage;
+    long max_ram_usage;
+    getrusage(RUSAGE_SELF, &usage);
+    max_ram_usage = usage.ru_maxrss;
+    return max_ram_usage;
+}
+
 int advice_chrome_tracing_t::with_flow(const char *module,
                                        const char *function,
                                        const char *flow,
@@ -499,16 +583,17 @@ int advice_chrome_tracing_t::with_flow(const char *module,
     int rc;
     char *json_str;
     json_t *event, *ph;
+    double my_ts;
 
     if (m_enable_logging)
     {
-        if ((rc = create_event(&event, module, function)) < 0)
+        if ((rc = create_event(&event, module, function, my_ts)) < 0)
         {
             return rc;
         }
         if (std::string("in") == flow)
         {
-            if ((rc = encode_event(event, "f", nullptr, "e", -1)) < 0)
+            if ((rc = encode_event(event, "f", nullptr, "e", -1, -1, -1)) < 0)
             {
                 json_decref(event);
                 return rc;
@@ -516,7 +601,7 @@ int advice_chrome_tracing_t::with_flow(const char *module,
         }
         else if (std::string("out") == flow)
         {
-            if ((rc = encode_event(event, "s", nullptr, "e", -1)) < 0)
+            if ((rc = encode_event(event, "s", nullptr, "e", -1, -1, -1)) < 0)
             {
                 json_decref(event);
                 return rc;
@@ -564,19 +649,21 @@ int advice_chrome_tracing_t::with_flow(const char *module,
 
 int advice_chrome_tracing_t::before(const char *module,
                                     const char *function,
-                                    const char *flow)
+                                    const char *flow,
+                                    const char *pcut)
 {
     int rc;
     char *json_str;
-    json_t *event, *ph;
+    json_t *event, *ph, *jtemp;
+    double my_ts = 0, cpu_start, wall_start;
+    std::string fname;
+    long mem_start;
 
     if (m_enable_logging)
     {
-        if ((rc = create_event(&event, module, function)) < 0)
-        {
+        if ((rc = create_event(&event, module, function, my_ts)) < 0)
             return rc;
-        }
-        if ((rc = encode_event(event, "B", nullptr, nullptr, -1)) < 0)
+        if ((rc = encode_event(event, "B", nullptr, nullptr, -1, -1, -1)) < 0)
         {
             json_decref(event);
             return rc;
@@ -591,6 +678,32 @@ int advice_chrome_tracing_t::before(const char *module,
         {
             json_decref(event);
             return rc;
+        }
+
+        if (std::string("around") == pcut && std::string("True") == metric_var)
+        {
+            jtemp = json_object_get(event, "name");
+            std::string my_name = json_string_value(jtemp);
+            jtemp = json_object_get(event, "pid");
+            int my_pid = (int) json_integer_value(jtemp);
+            jtemp = json_object_get(event, "tid");
+            int my_tid = (int) json_integer_value(jtemp);
+
+            fname = my_name + "_" + std::to_string(my_pid) + "_" + std::to_string(
+                        my_tid) + ".txt";
+            std::ofstream myfile(fname.c_str());
+            cpu_start = get_cpu_time();
+            wall_start = get_wall_time();
+            mem_start = get_memory_usage();
+
+            if (myfile.is_open())
+            {
+                myfile << std::to_string(cpu_start) << "\n";
+                myfile << std::to_string(wall_start) << "\n";
+                myfile << std::to_string(my_ts) << "\n";
+                myfile << std::to_string(mem_start) << "\n";
+                myfile.close();
+            };
         }
 
         free(json_str);
@@ -622,11 +735,24 @@ int advice_chrome_tracing_t::before(const char *module,
 
 int advice_chrome_tracing_t::after(const char *module,
                                    const char *function,
-                                   const char *flow)
+                                   const char *flow,
+                                   const char *pcut)
 {
+    double cpu_usage, wall_time;
+    long mem_usage;
+    if (std::string("around") == pcut)
+    {
+        cpu_usage = get_cpu_time();
+        wall_time = get_wall_time();
+        mem_usage =  get_memory_usage();
+    }
+
     int rc;
     char *json_str;
-    json_t *event, *ph;
+    json_t *event, *ph, *jtemp;
+    double my_ts = 0, prev_ts, cpu_start, wall_start, cpu_percentage;
+    std::string line, fname;
+    long mem_start;
 
     if (m_enable_logging)
     {
@@ -646,11 +772,9 @@ int advice_chrome_tracing_t::after(const char *module,
                 return rc;
             }
         }
-        if ((rc = create_event(&event, module, function)) < 0)
-        {
+        if ((rc = create_event(&event, module, function, my_ts)) < 0)
             return rc;
-        }
-        if ((rc = encode_event(event, "E", nullptr, nullptr, -1)) < 0)
+        if ((rc = encode_event(event, "E", nullptr, nullptr, -1, -1, -1)) < 0)
         {
             json_decref(event);
             return rc;
@@ -666,6 +790,85 @@ int advice_chrome_tracing_t::after(const char *module,
             json_decref(event);
             return rc;
         }
+
+        if (std::string("around") == pcut && std::string("True") == metric_var)
+        {
+            jtemp = json_object_get(event, "name");
+            std::string my_name = json_string_value(jtemp);
+            jtemp = json_object_get(event, "pid");
+            int my_pid = (int) json_integer_value(jtemp);
+            jtemp = json_object_get(event, "tid");
+            int my_tid = (int) json_integer_value(jtemp);
+
+            fname = my_name + "_" + std::to_string(my_pid) + "_" + std::to_string(
+                        my_tid) + ".txt";
+            std::ifstream myfile(fname.c_str());
+            if (myfile.is_open())
+            {
+                std::vector<std::string> lines;
+                while (getline(myfile, line))
+                {
+                    lines.push_back(line);
+                }
+                cpu_start = std::stod(lines[0]);
+                wall_start = std:: stod(lines[1]);
+                prev_ts = std::stod(lines[2]);
+                mem_start = std::stol(lines[3]);
+                myfile.close();
+
+                int status = remove(fname.c_str());
+                if (status != 0)
+                    std::perror("Error deleting file\n");
+            }
+
+            cpu_usage = cpu_usage - cpu_start;
+            if (cpu_usage < 0.0001)
+            {
+                cpu_usage = 0;
+            }
+            wall_time = wall_time - wall_start;
+            cpu_percentage = (cpu_usage / wall_time) * 100;
+
+            if ((rc = create_event(&event, module, function, prev_ts)) < 0)
+                return rc;
+            if ((rc = encode_event(event, "C", nullptr, nullptr, -1, cpu_percentage,
+                                   mem_usage)) < 0)
+            {
+                json_decref(event);
+                return rc;
+            }
+            if (!(json_str = json_dumps(event, JSON_INDENT(0))))
+            {
+                json_decref(event);
+                errno = ENOMEM;
+                return -1;
+            }
+            if ((rc = write_to_sstream(json_str)) < 0)
+            {
+                json_decref(event);
+                return rc;
+            }
+
+            if ((rc = create_event(&event, module, function, my_ts)) < 0)
+                return rc;
+            if ((rc = encode_event(event, "C", nullptr, nullptr, -1, 0.0, 0.0)) < 0)
+            {
+                json_decref(event);
+                return rc;
+            }
+            if (!(json_str = json_dumps(event, JSON_INDENT(0))))
+            {
+                json_decref(event);
+                errno = ENOMEM;
+                return -1;
+            }
+            if ((rc = write_to_sstream(json_str)) < 0)
+            {
+                json_decref(event);
+                return rc;
+            }
+        }
+
         free(json_str);
         json_decref(event);
         return flush_if(FLUSH_SIZE);
@@ -684,10 +887,11 @@ int advice_chrome_tracing_t::before_async(const char *module,
     int rc;
     char *json_str;
     json_t *event, *ph, *sc;
+    double my_ts;
 
     if (m_enable_logging)
     {
-        if ((rc = create_event(&event, module, function)) < 0)
+        if ((rc = create_event(&event, module, function, my_ts)) < 0)
         {
             return rc;
         }
@@ -697,7 +901,7 @@ int advice_chrome_tracing_t::before_async(const char *module,
             return rc;
         }
         if ((rc = encode_event(event, "b", scope, nullptr,
-                               m_before_counter)) < 0)
+                               m_before_counter, -1, -1)) < 0)
         {
             json_decref(event);
             return rc;
@@ -754,6 +958,7 @@ int advice_chrome_tracing_t::after_async(const char *module,
     int rc;
     char *json_str;
     json_t *event, *ph, *sc;
+    double my_ts;
 
     if (m_enable_logging)
     {
@@ -773,7 +978,7 @@ int advice_chrome_tracing_t::after_async(const char *module,
                 return rc;
             }
         }
-        if ((rc = create_event(&event, module, function)) < 0)
+        if ((rc = create_event(&event, module, function, my_ts)) < 0)
         {
             return rc;
         }
@@ -783,7 +988,7 @@ int advice_chrome_tracing_t::after_async(const char *module,
             return rc;
         }
         if ((rc = encode_event(event, "e", scope,
-                               nullptr, m_after_counter)) < 0)
+                               nullptr, m_after_counter, -1, -1)) < 0)
         {
             json_decref(event);
             return rc;

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -50,8 +50,6 @@ private:
     const std::string get_uniq_id_from_foreign_wm ();
     const std::string get_perfflow_instance_path ();
     int set_perfflow_instance_path (const std::string &path);
-    int set_metrics_var(const std::string value);
-    const std::string get_metrics_var();
 
     const int FLUSH_SIZE = 16777216;
     std::ostringstream m_oss;
@@ -60,11 +58,11 @@ private:
     int m_enable_logging = 0;
     int m_before_counter = 0;
     int m_after_counter = 0;
+    int m_usage_enable = 0;
     pthread_mutex_t m_before_counter_mutex;
     pthread_mutex_t m_after_counter_mutex;
     pthread_mutex_t m_mutex;
     std::map<std::string, std::string> m_perfflow_options;
-    std::string metric_var;
 };
 
 /*

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -22,9 +22,9 @@ public:
     advice_chrome_tracing_t ();
     virtual ~advice_chrome_tracing_t ();
     virtual int before (const char *module,
-                        const char *function, const char *flow);
+                        const char *function, const char *flow, const char *pcut);
     virtual int after (const char *module,
-                       const char *function, const char *flow);
+                       const char *function, const char *flow, const char *pcut);
     virtual int before_async (const char *module,
                               const char *function,
                               const char *scope, const char *flow);
@@ -32,14 +32,17 @@ public:
                              const char *function,
                              const char *scope,  const char *flow);
 private:
-    int create_event (json_t **o, const char *module, const char *function);
+    int create_event (json_t **o, const char *module, const char *function, double &my_ts);
     int get_timestamp (double &tstamp);
     int encode_event (json_t *o, const char *ph,
-                      const char *scope, const char *enclose, int64_t id);
+                      const char *scope, const char *enclose, int64_t id, double cpu_usage, long mem_usage);
     int with_flow (const char *module, const char *function,
                    const char *flow, int64_t id);
     int flush_if (size_t size);
     int write_to_sstream (const char *str);
+    double get_wall_time();
+    double get_cpu_time();
+    long get_memory_usage();
 
     int cannonicalize_perfflow_options ();
     int parse_perfflow_options ();
@@ -47,18 +50,21 @@ private:
     const std::string get_uniq_id_from_foreign_wm ();
     const std::string get_perfflow_instance_path ();
     int set_perfflow_instance_path (const std::string &path);
+    int set_metrics_var(const std::string value);
+    const std::string get_metrics_var();
 
     const int FLUSH_SIZE = 16777216;
     std::ostringstream m_oss;
     std::ofstream m_ofs;
     std::string m_fn = "";
-    int m_enable_logging = 1; /* Default should be true */
+    int m_enable_logging = 0;
     int m_before_counter = 0;
     int m_after_counter = 0;
     pthread_mutex_t m_before_counter_mutex;
     pthread_mutex_t m_after_counter_mutex;
     pthread_mutex_t m_mutex;
     std::map<std::string, std::string> m_perfflow_options;
+    std::string metric_var;
 };
 
 /*

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -55,7 +55,7 @@ private:
     std::ostringstream m_oss;
     std::ofstream m_ofs;
     std::string m_fn = "";
-    int m_enable_logging = 0;
+    int m_enable_logging = 1; /* Default should be true */
     int m_before_counter = 0;
     int m_after_counter = 0;
     int m_usage_enable = 0;

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -50,8 +50,6 @@ private:
     const std::string get_uniq_id_from_foreign_wm ();
     const std::string get_perfflow_instance_path ();
     int set_perfflow_instance_path (const std::string &path);
-    int set_metrics_var(const std::string value);
-    const std::string get_metrics_var();
 
     const int FLUSH_SIZE = 16777216;
     std::ostringstream m_oss;
@@ -65,7 +63,6 @@ private:
     pthread_mutex_t m_after_counter_mutex;
     pthread_mutex_t m_mutex;
     std::map<std::string, std::string> m_perfflow_options;
-    std::string metric_var;
 };
 
 /*

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -50,6 +50,8 @@ private:
     const std::string get_uniq_id_from_foreign_wm ();
     const std::string get_perfflow_instance_path ();
     int set_perfflow_instance_path (const std::string &path);
+    int set_metrics_var(const std::string value);
+    const std::string get_metrics_var();
 
     const int FLUSH_SIZE = 16777216;
     std::ostringstream m_oss;
@@ -63,6 +65,7 @@ private:
     pthread_mutex_t m_after_counter_mutex;
     pthread_mutex_t m_mutex;
     std::map<std::string, std::string> m_perfflow_options;
+    std::string metric_var;
 };
 
 /*

--- a/src/c/runtime/perfflow_runtime.cpp
+++ b/src/c/runtime/perfflow_runtime.cpp
@@ -49,7 +49,8 @@ extern "C" void perfflow_weave_before(int async,
                                       const char *module,
                                       const char *function,
                                       const char *scope,
-                                      const char *flow)
+                                      const char *flow,
+                                      const char *pcut)
 {
     if (advice == nullptr)
     {
@@ -61,7 +62,7 @@ extern "C" void perfflow_weave_before(int async,
     }
     else
     {
-        advice->before(module, function, flow);
+        advice->before(module, function, flow, pcut);
     }
     return;
 }
@@ -70,7 +71,8 @@ extern "C" void perfflow_weave_after(int async,
                                      const char *module,
                                      const char *function,
                                      const char *scope,
-                                     const char *flow)
+                                     const char *flow,
+                                     const char *pcut)
 {
     if (advice == nullptr)
     {
@@ -82,7 +84,7 @@ extern "C" void perfflow_weave_after(int async,
     }
     else
     {
-        advice->after(module, function, flow);
+        advice->after(module, function, flow, pcut);
     }
     return;
 }

--- a/src/c/weaver/weave/perfflow_weave.hpp
+++ b/src/c/weaver/weave/perfflow_weave.hpp
@@ -31,9 +31,9 @@ public:
 
 private:
     bool insertAfter (Module &m, Function &f, StringRef &a,
-                      int async, std::string &scope, std::string &flow);
+                      int async, std::string &scope, std::string &flow, std::string pcut);
     bool insertBefore (Module &m, Function &f, StringRef &a,
-                       int async, std::string &scope, std::string &flow);
+                       int async, std::string &scope, std::string &flow, std::string pcut);
 };
 
 }


### PR DESCRIPTION
This PR contains the following enhancement:
- Measure the CPU and Memory usage of annotated function with "around" pointcut in C
- Measure the CPU and Memory usage only if environment variable "cpu_mem_usage" as part of PERFFLOW_OPTIONS is set to True. Default is False.