### PR TITLE
Python: Async Events need an ID to work with Perfetto

### DIFF
--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -225,6 +225,8 @@ class ChromeTracingAdvice:
         event["ph"] = ph
         if id:
             event["id"] = id
+        else:
+            event["id"] = "123" #Async events need an ID, this sets the default.
         if scope:
             event["scope"] = scope
         return event

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -226,7 +226,7 @@ class ChromeTracingAdvice:
         if id:
             event["id"] = id
         else:
-            event["id"] = "123" #Async events need an ID, this sets the default.
+            event["id"] = 123  # Async events need an ID, this sets the default.
         if scope:
             event["scope"] = scope
         return event


### PR DESCRIPTION
This PR fixes a bug and sets a default ID to 123 when it is not set.
Closes #20. 