### PR TITLE
add VSCode DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:20.04
+
+# export PATH=/usr/local/cuda-12.1/bin/:$PATH
+# cd src/c
+# mkdir build
+# cd build
+# cmake -DCMAKE_CXX_COMPILER=clang++ -DLLVM_DIR=/usr/lib/llvm-10/cmake ..
+
+LABEL maintainer="Vanessasaurus <@vsoch>"
+
+# Match the default user id for a single system so we aren't root
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+ENV USERNAME=${USERNAME}
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt install -y clang llvm-dev libjansson-dev libssl-dev \
+    wget bison flex make cmake mpich python3 python3-pip sudo llvm-12 \
+    sudo pciutils
+
+# install cuda 12.1 (note uncomment this if you can support on your development machine!)
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin && \
+    mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
+    wget https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda-repo-ubuntu2004-12-1-local_12.1.0-530.30.02-1_amd64.deb && \
+    dpkg -i cuda-repo-ubuntu2004-12-1-local_12.1.0-530.30.02-1_amd64.deb && \
+    cp /var/cuda-repo-ubuntu2004-12-1-local/cuda-*-keyring.gpg /usr/share/keyrings/ && \
+    apt-get update && \
+    apt-get -y install cuda && \
+    ln -s -T /usr/bin/make /usr/bin/gmake
+
+ENV PATH=/usr/local/cuda-12.1/bin:$PATH
+
+# Python helpers
+RUN python3 -m pip install --upgrade pip pytest setuptools flake8 rstfmt black
+#    sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-12 200
+
+RUN ldconfig
+
+# Add the group and user that match our ids
+RUN groupadd -g ${USER_GID} ${USERNAME} && \
+    adduser --disabled-password --uid ${USER_UID} --gid ${USER_GID} --gecos "" ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "name": "PerfFlowAspect Development Environment",
+    "dockerFile": "Dockerfile",
+    "context": "../"
+}

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -1,0 +1,72 @@
+name: build PerfFlowAspect
+
+on:
+
+  # Publish packages on release
+  release:
+    types: [published]
+
+  # We might want to remove this, OR provide a base container
+  # that will more quickly build from, or use cache
+  pull_request: []
+
+  # On push to main we build and deploy images
+  push:
+    branches:
+    - main
+
+jobs:
+  build:
+    permissions:
+      packages: write
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: [[".devcontainer/Dockerfile", ".", "ghcr.io/flux-framework/perf-flow-aspect-base"]]
+        # TODO add the container with PerfFlowAspect after base is built
+
+    name: Build ${{ matrix.container[2] }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      
+    - name: Make Space For Build
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+
+    - name: Pull Layers
+      env:
+        container: ${{ matrix.container[2] }}
+      run: docker pull ${container} || echo "No layers to pull for ${container}"
+
+    - name: Build Container
+      env:
+        dockerfile: ${{ matrix.container[0] }}
+        container: ${{ matrix.container[2] }}
+        context: ${{ matrix.container[1] }}
+      run: docker build -f ${dockerfile} -t ${container} ${context}
+
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Tag and Push Release Image
+      if: (github.event_name == 'release')
+      env:
+        container: ${{ matrix.container[2] }}
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "Tagging and releasing ${container}:${tag}"
+        docker tag ${container}:latest ${container}:${tag}
+        docker push ${container}:${tag}
+
+    - name: Deploy
+      if: (github.event_name != 'pull_request')
+      run: docker push ${container}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+src/c/build
 src/c/parser/lex.yy.c
 src/c/parser/lex.yy.o
 src/c/parser/libperfflow_parser.so

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -1,0 +1,73 @@
+############################
+ PerfFlowAspect Development
+############################
+
+This is a short developer guide for using the included development environment.
+We provide both a base container for `VSCode
+<https://code.visualstudio.com/docs/remote/containers>`_, and a production
+container with PerfFlowAspect you can use for application development outside of
+that. This is done via the `.devcontainer
+<https://code.visualstudio.com/docs/remote/containers#_create-a-devcontainerjson-file`_
+directory. You can follow the `DevContainers tutorial
+<https://code.visualstudio.com/docs/remote/containers-tutorial>`_ where you'll
+basically need to:
+
+#. Install Docker, or compatible engine
+#. Install the Development Containers extension
+
+Then you can go to the command palette (View -> Command Palette) and select
+``Dev Containers: Open Workspace in Container.`` and select your cloned
+PerfFlowAspect repository root. This will build a development environment. You
+are free to change the base image and rebuild if you need to test on another
+operating system! When your container is built, when you open ``Terminal -> New
+Terminal`` you'll be in the container, which you can tell based on being the
+"vscode" user. You can then proceed to the sections below to build and test
+PerfFlowAspect.
+
+**Important** the development container assumes you are on a system with uid
+1000 and gid 1000. If this isn't the case, edit the ``.devcontainer/Dockerfile``
+to be your user and group id. This will ensure changes written inside the
+container are owned by your user. It's recommended that you commit on your
+system (not inside the container) because if you need to sign your commits, the
+container doesn't have access and won't be able to. If you find that you
+accidentally muck up permissions and need to fix, you can run this from your
+terminal outside of VSCode:
+
+.. code:: console
+
+   $ sudo chown -R $USER .git/
+   # and then commit
+
+***************************
+ Installing PerfFlowAspect
+***************************
+
+Once inside the development environment, you can compile PerfFlowAspect:
+
+.. code:: console
+
+   export PATH=/usr/local/cuda-12.1/bin/:$PATH
+   cd src/c
+   mkdir build
+   cd build
+   cmake -DCMAKE_CXX_COMPILER=clang++ -DLLVM_DIR=/usr/lib/llvm-10/cmake ..
+   make
+   sudo make install
+
+If you want to run tests, cd to where the tests are, and run a few!
+
+.. code:: console
+
+   cd src/c/build/test
+   ./t0001-cbinding-basic.t
+
+Note that if you don't have a GPU, these probably will error (I do not)! Here is
+how to run Python tests:
+
+.. code:: console
+
+   cd src/python/test
+   ./t0001-pybinding-basic.t
+
+You'll again have issues without an actual GPU. And that's it! Note that we will
+update this documentation as we create more examples.


### PR DESCRIPTION
okay - second time is the charm! With @slabasan magic touch, this seemed to work the second time around! This pull request will:

- Add a VSCode DevContainer to make it easy to develop PerfFlowAspect
- Add a developer.rst file with instructions for interaction
- Add an automated build to push the container base to GitHub packages

This will close #112 

Once we have the automated build for `ghcr.io/flux-framework/perf-flow-aspect-base` we can very easily add one for just `"ghcr.io/flux-framework/perf-flow-aspect"` The use case is wanting a container, ready to go, to develop your application with PerfFlowAspect.

This PR and the subsequent one (I'll open after the container deploys) will subsume #114. With the second container I'll update the developer.rst with another section for how to get started with an example Python app, for example.