### PR TITLE
Caliper instrumentation

### DIFF
--- a/src/c/runtime/CMakeLists.txt
+++ b/src/c/runtime/CMakeLists.txt
@@ -13,16 +13,16 @@ set(perfflow_runtime_sources
 )
 
 find_package(OpenSSL REQUIRED)
+find_package(caliper REQUIRED)
 
-set(perfflow_runtime_deps -ljansson
-)
+set(perfflow_runtime_deps -ljansson)
 
 add_library(perfflow_runtime SHARED
             ${perfflow_runtime_sources}
             ${perfflow_runtime_headers}
 )
 
-target_link_libraries(perfflow_runtime ${perfflow_runtime_deps} OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(perfflow_runtime ${perfflow_runtime_deps} OpenSSL::SSL OpenSSL::Crypto caliper)
 
 install(TARGETS perfflow_runtime
         EXPORT perfflow_export

--- a/src/c/test/CMakeLists.txt
+++ b/src/c/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SMOKETESTS
 find_package(MPI REQUIRED)
 find_package(Threads REQUIRED)
 find_package(CUDA REQUIRED)
+find_package(caliper REQUIRED)
 include_directories(${MPI_INCLUDE_PATH})
 
 set(perfflow_deps "-L../runtime -lperfflow_runtime -lcrypto")
@@ -22,13 +23,13 @@ foreach(TEST ${SMOKETESTS})
     target_link_libraries(${TEST} ${MPI_LIBRARIES})
     target_link_libraries(${TEST} pthread)
     set_source_files_properties(${TEST}.cpp COMPILE_FLAGS "-Xclang -load -Xclang ../weaver/weave/libWeavePass.so -fPIC")
-    target_link_libraries(${TEST} ${perfflow_deps})
+    target_link_libraries(${TEST} ${perfflow_deps} caliper)
 endforeach()
 
 message(STATUS " [*] Adding test: smoketest_cuda")
 set(CUDA_NVCC_FLAGS  "-ccbin ${CMAKE_CXX_COMPILER} -Xcompiler=-Xclang -Xcompiler=-load -Xcompiler=-Xclang -Xcompiler=../../../weaver/weave/libWeavePass.so")
 cuda_add_executable(smoketest_cuda smoketest_cuda_wrapper.cpp smoketest_cuda_kernel.cu)
-target_link_libraries(smoketest_cuda ${perfflow_deps} ${CUDA_LIBRARIES} cuda)
+target_link_libraries(smoketest_cuda ${perfflow_deps} ${CUDA_LIBRARIES} cuda caliper)
 
 configure_file(t0001-cbinding-basic.t.in
     ${CMAKE_CURRENT_BINARY_DIR}/t0001-cbinding-basic.t

--- a/src/c/weaver/weave/perfflow_weave.hpp
+++ b/src/c/weaver/weave/perfflow_weave.hpp
@@ -11,9 +11,13 @@
 #ifndef PERFFLOW_WEAVE_H
 #define PERFFLOW_WEAVE_H
 
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
 
 #include <string>
 
@@ -24,6 +28,9 @@ namespace {
 class WeavingPass : public FunctionPass
 {
 public:
+    FunctionCallee CaliBeginRegion;
+    FunctionCallee CaliEndRegion;
+
     static char ID;
     WeavingPass () : FunctionPass (ID) {}
     virtual bool doInitialization (Module &m);
@@ -34,6 +41,8 @@ private:
                       int async, std::string &scope, std::string &flow, std::string pcut);
     bool insertBefore (Module &m, Function &f, StringRef &a,
                        int async, std::string &scope, std::string &flow, std::string pcut);
+
+    bool instrumentCaliper(Module &M, Function &F);
 };
 
 }


### PR DESCRIPTION
Adds Caliper instrumentation to PerfFlow annotated functions. Instrumentation is added before weaver instrumentation.

Co-authored-by: Giorgis Georgakoudis <georgakoudis1@llnl.gov>, daboehme <boehme3@llnl.gov>

Fixes #120 