### PR TITLE
Refactor cmake build system

### DIFF
--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -2,12 +2,10 @@ cmake_minimum_required(VERSION 3.12)
 
 project(PerfFlowAspect VERSION "0.1.0")
 
-# Fail if someone tries to config an in-source build.
-if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
-   message(FATAL_ERROR "In-source builds are not supported. Please remove "
-                       "CMakeCache.txt from the 'src' dir and configure an "
-                       "out-of-source build in another directory.")
-endif()
+# Build Options
+option(PERFFLOWASPECT_WITH_CUDA "Build CUDA smoketest" ON)
+option(PERFFLOWASPECT_WITH_MPI "Build MPI smoketest" ON)
+option(PERFFLOWASPECT_WITH_MULTITHREADS "Build multi-threaded smoketest" ON)
 
 # Fail if using Clang < 9.0
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -24,30 +22,15 @@ else()
     message(WARNING "Unsupported CXX compiler: please use Clang >= 9.0")
 endif()
 
-# Always use position independent code
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+include(cmake/CMakeBasics.cmake)
 
-# Set build type
-set(default_build_type "Debug")
-
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Using default build type: \"${default_build_type}\"")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-      STRING "Choose the type of build." FORCE)
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-else()
-  message(STATUS "Setting build type to \"${CMAKE_BUILD_TYPE}\"")
-endif()
-
+include(cmake/Setup3rdParty.cmake)
 
 include(GNUInstallDirs)
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-message(STATUS "CMAKE_INSTALL_RPATH = ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-
 
 # the RPATH to be used when installing, but only if it's not a system directory
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
@@ -55,7 +38,6 @@ list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
 if("${isSystemDir}" STREQUAL "-1")
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 endif("${isSystemDir}" STREQUAL "-1")
-
 
 add_subdirectory(parser)
 add_subdirectory(runtime)
@@ -66,18 +48,19 @@ add_library(perfflowaspect INTERFACE)
 target_link_libraries(perfflowaspect INTERFACE perfflow_runtime perfflow_parser WeavePassPlugin)
 install(TARGETS perfflowaspect
         EXPORT perfflow_export
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} 
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} 
-        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR} 
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 add_subdirectory(config)
 
-message(STATUS "Config Dir: ${PERFFLOWASPECT_INSTALL_CONFIG_DIR}")
-
-if (NOT DEFINED PERFFLOWASPECT_INSTALL_CONFIG_DIR)
+if(NOT DEFINED PERFFLOWASPECT_INSTALL_CONFIG_DIR)
     set(PERFFLOWASPECT_INSTALL_CONFIG_DIR "share")
 endif()
+
+message(STATUS "CMAKE_INSTALL_RPATH = ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+message(STATUS "Config Dir: ${CMAKE_INSTALL_PREFIX}/${PERFFLOWASPECT_INSTALL_CONFIG_DIR}")
 
 install(EXPORT perfflow_export
     FILE perfflowaspect_targets.cmake

--- a/src/c/cmake/CMakeBasics.cmake
+++ b/src/c/cmake/CMakeBasics.cmake
@@ -1,0 +1,21 @@
+# Fail if someone tries to config an in-source build.
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+   message(FATAL_ERROR "In-source builds are not supported. Please remove "
+                       "CMakeCache.txt from the 'src' dir and configure an "
+                       "out-of-source build in another directory.")
+endif()
+
+# Always use position independent code
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Set build type
+set(default_build_type "Debug")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Using default build type: \"${default_build_type}\"")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+else()
+  message(STATUS "Setting build type to \"${CMAKE_BUILD_TYPE}\"")
+endif()

--- a/src/c/cmake/Setup3rdParty.cmake
+++ b/src/c/cmake/Setup3rdParty.cmake
@@ -1,0 +1,21 @@
+include(cmake/thirdparty/FindBison.cmake)
+
+if(PERFFLOWASPECT_WITH_CUDA)
+    include(cmake/thirdparty/FindCUDA.cmake)
+endif()
+
+include(cmake/thirdparty/FindFlex.cmake)
+
+include(cmake/thirdparty/FindJansson.cmake)
+
+include(cmake/thirdparty/FindLLVM.cmake)
+
+if(PERFFLOWASPECT_WITH_MPI)
+    include(cmake/thirdparty/FindMPI.cmake)
+endif()
+
+include(cmake/thirdparty/FindOpenSSL.cmake)
+
+if(PERFFLOWASPECT_WITH_MULTITHREADS)
+    include(cmake/thirdparty/FindThreads.cmake)
+endif()

--- a/src/c/cmake/thirdparty/FindBison.cmake
+++ b/src/c/cmake/thirdparty/FindBison.cmake
@@ -1,0 +1,1 @@
+find_package(BISON REQUIRED)

--- a/src/c/cmake/thirdparty/FindCUDA.cmake
+++ b/src/c/cmake/thirdparty/FindCUDA.cmake
@@ -1,0 +1,5 @@
+find_package(CUDA)
+
+if(PERFFLOWASPECT_WITH_CUDA)
+    message(STATUS "Building CUDA smoketest (PERFFLOWASPECT_WITH_CUDA == ON)")
+endif()

--- a/src/c/cmake/thirdparty/FindFlex.cmake
+++ b/src/c/cmake/thirdparty/FindFlex.cmake
@@ -1,0 +1,1 @@
+find_package(FLEX REQUIRED)

--- a/src/c/cmake/thirdparty/FindJansson.cmake
+++ b/src/c/cmake/thirdparty/FindJansson.cmake
@@ -1,0 +1,55 @@
+# First check for user-specified JANSSON_DIR
+if(JANSSON_DIR)
+    message(STATUS "Looking for Jansson using JANSSON_DIR = ${JANSSON_DIR}")
+
+    find_path(JANSSON_INCLUDE_DIRS
+        NAMES jansson.h
+        HINTS ${JANSSON_DIR}/include
+    )
+    if(NOT JANSSON_INCLUDE_DIRS)
+        MESSAGE(FATAL_ERROR "Could not find jansson.h in ${JANSSON_DIR}/include")
+    endif()
+
+    find_library(JANSSON_LIBRARY
+        NAMES libjansson.so
+        HINTS ${JANSSON_DIR}/lib
+    )
+    if(NOT JANSSON_LIBRARY)
+        MESSAGE(FATAL_ERROR "Could not find libjansson.so in ${JANSSON_DIR}/lib")
+    endif()
+
+    set(JANSSON_FOUND TRUE CACHE INTERNAL "")
+    set(JANSSON_DIR ${JANSSON_DIR} CACHE PATH "" FORCE)
+    include_directories(${JANSSON_INCLUDE_DIRS})
+
+    message(STATUS "FOUND jansson")
+    message(STATUS " [*] JANSSON_DIR = ${JANSSON_DIR}")
+    message(STATUS " [*] JANSSON_INCLUDE_DIRS = ${JANSSON_INCLUDE_DIRS}")
+    message(STATUS " [*] JANSSON_LIBRARY = ${JANSSON_LIBRARY}")
+# If JANSSON_DIR not specified, then try to automatically find the JANSSON header
+# and library
+elseif(NOT JANSSON_FOUND)
+    find_path(JANSSON_INCLUDE_DIRS
+        NAMES jansson.h
+    )
+
+    find_library(JANSSON_LIBRARY
+        NAMES libjansson.so
+    )
+
+    if(JANSSON_INCLUDE_DIRS AND JANSSON_LIBRARY)
+        set(JANSSON_FOUND TRUE CACHE INTERNAL "")
+        set(JANSSON_INCLUDE_DIRS ${JANSSON_INCLUDE_DIRS} CACHE PATH "" FORCE)
+        set(JANSSON_LIBRARY ${JANSSON_LIBRARY} CACHE PATH "" FORCE)
+        include_directories(${JANSSON_INCLUDE_DIRS})
+
+        message(STATUS "FOUND jansson using find_library()")
+        message(STATUS " [*] JANSSON_INCLUDE_DIRS = ${JANSSON_INCLUDE_DIRS}")
+        message(STATUS " [*] JANSSON_LIBRARY = ${JANSSON_LIBRARY}")
+    endif()
+endif()
+
+# Abort if all methods fail
+if(NOT JANSSON_FOUND)
+    message(FATAL_ERROR "Jansson support needs explict JANSSON_DIR")
+endif()

--- a/src/c/cmake/thirdparty/FindLLVM.cmake
+++ b/src/c/cmake/thirdparty/FindLLVM.cmake
@@ -1,0 +1,1 @@
+find_package(LLVM REQUIRED CONFIG)

--- a/src/c/cmake/thirdparty/FindMPI.cmake
+++ b/src/c/cmake/thirdparty/FindMPI.cmake
@@ -1,0 +1,5 @@
+find_package(MPI REQUIRED)
+
+if(PERFFLOWASPECT_WITH_MPI)
+    message(STATUS "Building MPI smoketest (PERFFLOWASPECT_WITH_MPI == ON)")
+endif()

--- a/src/c/cmake/thirdparty/FindOpenSSL.cmake
+++ b/src/c/cmake/thirdparty/FindOpenSSL.cmake
@@ -1,0 +1,1 @@
+find_package(OpenSSL REQUIRED)

--- a/src/c/cmake/thirdparty/FindThreads.cmake
+++ b/src/c/cmake/thirdparty/FindThreads.cmake
@@ -1,0 +1,5 @@
+find_package(Threads REQUIRED)
+
+if(PERFFLOWASPECT_WITH_MULTITHREADS)
+    message(STATUS "Building multi-threaded smoketest (PERFFLOWASPECT_WITH_MULTITHREADS == ON)")
+endif()

--- a/src/c/parser/CMakeLists.txt
+++ b/src/c/parser/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_package(BISON REQUIRED)
-find_package(FLEX REQUIRED)
-
 set(LEX_FLAGS "--nodefault")
 
 set(YACC_FLAGS "-t --report=none")

--- a/src/c/runtime/CMakeLists.txt
+++ b/src/c/runtime/CMakeLists.txt
@@ -12,17 +12,12 @@ set(perfflow_runtime_sources
     perfflow_runtime.cpp
 )
 
-find_package(OpenSSL REQUIRED)
-
-set(perfflow_runtime_deps -ljansson
-)
-
 add_library(perfflow_runtime SHARED
             ${perfflow_runtime_sources}
             ${perfflow_runtime_headers}
 )
 
-target_link_libraries(perfflow_runtime ${perfflow_runtime_deps} OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(perfflow_runtime ${JANSSON_LIBRARY} OpenSSL::SSL OpenSSL::Crypto)
 
 install(TARGETS perfflow_runtime
         EXPORT perfflow_export

--- a/src/c/test/CMakeLists.txt
+++ b/src/c/test/CMakeLists.txt
@@ -7,10 +7,9 @@ set(SMOKETESTS
     smoketest_MT
 )
 
-find_package(MPI REQUIRED)
-find_package(Threads REQUIRED)
-find_package(CUDA)
-include_directories(${MPI_INCLUDE_PATH})
+if(MPI_FOUND)
+    include_directories(${MPI_INCLUDE_PATH})
+endif()
 
 set(perfflow_deps "-L../runtime -lperfflow_runtime -lcrypto")
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/src/c/test/CMakeLists.txt
+++ b/src/c/test/CMakeLists.txt
@@ -11,7 +11,7 @@ if(MPI_FOUND)
     include_directories(${MPI_INCLUDE_PATH})
 endif()
 
-set(perfflow_deps "-L../runtime -lperfflow_runtime -lcrypto")
+set(perfflow_deps "-L../runtime -lperfflow_runtime" OpenSSL::Crypto)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 message(STATUS "Adding CXX unit tests")

--- a/src/c/weaver/CMakeLists.txt
+++ b/src/c/weaver/CMakeLists.txt
@@ -1,9 +1,10 @@
 # support C++14 features used by LLVM 10.0.0
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(LLVM REQUIRED CONFIG)
-add_definitions(${LLVM_DEFINITIONS})
-include_directories(${LLVM_INCLUDE_DIRS})
-link_directories(${LLVM_LIBRARY_DIRS})
+if(LLVM_FOUND)
+    add_definitions(${LLVM_DEFINITIONS})
+    include_directories(${LLVM_INCLUDE_DIRS})
+    link_directories(${LLVM_LIBRARY_DIRS})
+endif()
 
 add_subdirectory(weave)

--- a/src/c/weaver/weave/CMakeLists.txt
+++ b/src/c/weaver/weave/CMakeLists.txt
@@ -12,8 +12,7 @@ set_target_properties(WeavePass PROPERTIES
     COMPILE_FLAGS "-fno-rtti"
 )
 
-find_library(JANSSON_LIB jansson)
-target_link_libraries(WeavePass perfflow_parser "${JANSSON_LIB}")
+target_link_libraries(WeavePass perfflow_parser ${JANSSON_LIB})
 
 add_library(WeavePassPlugin INTERFACE)
 target_compile_options(WeavePassPlugin INTERFACE


### PR DESCRIPTION
- move `find_package` to per-package files in cmake directory
- add missing `find_package` for `jansson`
- add build options for MPI, multi-threaded, and CUDA smoketests
- use defined targets for found modules

Fixes #132 