### PR TITLE
Enable option to toggle between array and object format

### DIFF
--- a/docs/BasicTutorial.rst
+++ b/docs/BasicTutorial.rst
@@ -101,6 +101,8 @@ variable. Separate multiple variables with a colon as follows:
 +----------------------+--------------------------------------------------------------+---------------+---------------------------------+
 | log-event            | Collect B and E events (verbose) or single X event (compact) | Verbose       | Verbose, Compact                |
 +----------------------+--------------------------------------------------------------+---------------+---------------------------------+
+| log-format           | Dump JSON events in array or object format                   | Array         | Array, Object                   |
++----------------------+--------------------------------------------------------------+---------------+---------------------------------+
 
 **********************************************
  Visualization of PerfFlowAspect Output Files

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -258,6 +258,10 @@ int advice_chrome_tracing_t::cannonicalize_perfflow_options()
     {
         m_perfflow_options["log-event"] = "Verbose";
     }
+    if (m_perfflow_options.find("log-format") == m_perfflow_options.end())
+    {
+        m_perfflow_options["log-format"] = "Array";
+    }
     return 0;
 }
 
@@ -441,6 +445,8 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
     //     PERFFLOW_OPTIONS="cpu-mem-usage=True"
     // To collect B (begin) and E (end) events as single X (complete) duration event (default: log-event=Verbose)
     //     PERFFLOW_OPTIONS="log-event=Compact"
+    // To output events in object format (default: log-format=Array)
+    //     PERFFLOW_OPTIONS="log-format=Object"
     // You can combine the options in colon (:) delimited format
 
     if (parse_perfflow_options() < 0)
@@ -488,6 +494,22 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
         {
             m_fn += "." + std::to_string(getpid());
         }
+    }
+
+    std::string log_format = m_perfflow_options["log-format"];
+    if (log_format == "Array" || log_format == "array" || log_format == "ARRAY")
+    {
+        m_array_format = 1;
+    }
+    else if (log_format == "Object" || log_format == "object" || log_format == "OBJECT")
+    {
+        m_array_format = 0;
+    }
+    else
+    {
+        throw std::system_error(errno,
+                                std::system_category(),
+                                "invalid log-format value");
     }
 
     m_fn += ".pfw";

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -501,7 +501,8 @@ advice_chrome_tracing_t::advice_chrome_tracing_t ()
     {
         m_array_format = 1;
     }
-    else if (log_format == "Object" || log_format == "object" || log_format == "OBJECT")
+    else if (log_format == "Object" || log_format == "object" ||
+             log_format == "OBJECT")
     {
         m_array_format = 0;
     }

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -60,6 +60,7 @@ private:
     int m_after_counter = 0;
     int m_cpu_mem_usage_enable = 0;
     int m_compact_event_enable = 0;
+    int m_array_format = 1;
     pthread_mutex_t m_before_counter_mutex;
     pthread_mutex_t m_after_counter_mutex;
     pthread_mutex_t m_mutex;

--- a/src/c/test/t0001-cbinding-basic.t.in
+++ b/src/c/test/t0001-cbinding-basic.t.in
@@ -43,162 +43,162 @@ EOF
 '
 
 test_expect_success 'c binding: correctly named ctf file produced' '
-    test -f perfflow.$(hostname).[0-9]*.pfw
+    test -f perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'c binding: ctf file appears good' '
-    sanity_check perfflow.$(hostname).[0-9]*.pfw &&
-    rm perfflow.$(hostname).[0-9]*.pfw
+    sanity_check perfflow.array.$(hostname).[0-9]*.pfw &&
+    rm perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: log-dir works' '
     PERFFLOW_OPTIONS="log-dir=./logdir" ../smoketest &&
-    sanity_check ./logdir/perfflow.$(hostname).[0-9]*.pfw &&
-    rm ./logdir/perfflow.$(hostname).[0-9]*.pfw
+    sanity_check ./logdir/perfflow.array.$(hostname).[0-9]*.pfw &&
+    rm ./logdir/perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: name can be included in filename' '
     PERFFLOW_OPTIONS="name=mycomponent:log-filename-include=name" \
 	../smoketest &&
-    test -f perfflow.mycomponent.pfw &&
-    sanity_check perfflow.mycomponent.pfw &&
-    rm perfflow.mycomponent.pfw
+    test -f perfflow.array.mycomponent.pfw &&
+    sanity_check perfflow.array.mycomponent.pfw &&
+    rm perfflow.array.mycomponent.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: instance-path included in filename' '
     PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
-    test -f perfflow.{[a-f0-9]*}.pfw &&
-    sanity_check perfflow.{[a-f0-9]*}.pfw &&
-    rm perfflow.{[a-f0-9]*}.pfw
+    test -f perfflow.array.{[a-f0-9]*}.pfw &&
+    sanity_check perfflow.array.{[a-f0-9]*}.pfw &&
+    rm perfflow.array.{[a-f0-9]*}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: filename includes all' '
     PERFFLOW_OPTIONS="log-filename-include=name,instance-path,hostname,pid" \
 	../smoketest &&
-    test -f perfflow.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw &&
-    sanity_check perfflow.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw &&
-    rm perfflow.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw
+    test -f perfflow.array.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw &&
+    sanity_check perfflow.array.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw &&
+    rm perfflow.array.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: filename includes all in correct order' '
     PERFFLOW_OPTIONS="log-filename-include=hostname,instance-path,pid,name" \
 	../smoketest &&
-    test -f perfflow.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw &&
-    sanity_check perfflow.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw &&
-    rm perfflow.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw
+    test -f perfflow.array.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw &&
+    sanity_check perfflow.array.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw &&
+    rm perfflow.array.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: SLURM supported' '
     SLURM_JOB_ID=123456 SLURM_STEP_ID=1 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
     sha1=$(echo -n "123456.1" | sha1sum | awk "{print \$1}" | cut -c1-8) &&
-    test -f perfflow.{${sha1}}.pfw &&
-    sanity_check perfflow.{${sha1}}.pfw &&
-    rm perfflow.{${sha1}}.pfw
+    test -f perfflow.array.{${sha1}}.pfw &&
+    sanity_check perfflow.array.{${sha1}}.pfw &&
+    rm perfflow.array.{${sha1}}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: LSF supported' '
     LSB_JOBID=123456 LS_JOBPID=1 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
     sha1=$(echo -n "123456.1" | sha1sum | awk "{print \$1}" | cut -c1-8) &&
-    test -f perfflow.{${sha1}}.pfw &&
-    sanity_check perfflow.{${sha1}}.pfw &&
-    rm perfflow.{${sha1}}.pfw
+    test -f perfflow.array.{${sha1}}.pfw &&
+    sanity_check perfflow.array.{${sha1}}.pfw &&
+    rm perfflow.array.{${sha1}}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: SLURM_JOB_ID + STEP_ID must be given' '
     SLURM_JOB_ID=123456 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
     sha1=$(echo -n "1" | sha1sum | awk "{print \$1}" | cut -c1-8) &&
-    test -f perfflow.{${sha1}}.pfw &&
-    sanity_check perfflow.{${sha1}}.pfw &&
-    rm perfflow.{${sha1}}.pfw
+    test -f perfflow.array.{${sha1}}.pfw &&
+    sanity_check perfflow.array.{${sha1}}.pfw &&
+    rm perfflow.array.{${sha1}}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: LSB_JOBID + LS_JOBPID must be given' '
     LSB_JOBID=123456 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
     sha1=$(echo -n "1" | sha1sum | awk "{print \$1}" | cut -c1-8) &&
-    test -f perfflow.{${sha1}}.pfw &&
-    sanity_check perfflow.{${sha1}}.pfw &&
-    rm perfflow.{${sha1}}.pfw
+    test -f perfflow.array.{${sha1}}.pfw &&
+    sanity_check perfflow.array.{${sha1}}.pfw &&
+    rm perfflow.array.{${sha1}}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: Flux supported' '
     FLUX_JOB_ID=123456 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
-    test -f perfflow.{123456}.pfw &&
-    sanity_check perfflow.{123456}.pfw &&
-    rm perfflow.{123456}.pfw
+    test -f perfflow.array.{123456}.pfw &&
+    sanity_check perfflow.array.{123456}.pfw &&
+    rm perfflow.array.{123456}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: Flux f58-encoded jobid supported' '
     FLUX_JOB_ID=ƒeF9QZG3 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
-    test -f perfflow.{ƒeF9QZG3}.pfw &&
-    sanity_check perfflow.{ƒeF9QZG3}.pfw &&
-    rm perfflow.{ƒeF9QZG3}.pfw
+    test -f perfflow.array.{ƒeF9QZG3}.pfw &&
+    sanity_check perfflow.array.{ƒeF9QZG3}.pfw &&
+    rm perfflow.array.{ƒeF9QZG3}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: nested instance-path supported' '
     PERFFLOW_INSTANCE_PATH=fffffff.444444 FLUX_JOB_ID=123456 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest &&
-    test -f perfflow.{fffffff.444444.123456}.pfw &&
-    sanity_check perfflow.{fffffff.444444.123456}.pfw &&
-    rm perfflow.{fffffff.444444.123456}.pfw
+    test -f perfflow.array.{fffffff.444444.123456}.pfw &&
+    sanity_check perfflow.array.{fffffff.444444.123456}.pfw &&
+    rm perfflow.array.{fffffff.444444.123456}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw &&
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then rm perfflow.$(hostname).[0-9]*.pfw; fi
+    ! test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then rm perfflow.array.$(hostname).[0-9]*.pfw; fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest' '
     PERFFLOW_OPTIONS="log-enable=True" ../smoketest &&
-    test -f perfflow.$(hostname).[0-9]*.pfw &&
-    rm perfflow.$(hostname).[0-9]*.pfw
+    test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+    rm perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest2' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest2 &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw &&
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then rm perfflow.$(hostname).[0-9]*.pfw; fi
+    ! test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then rm perfflow.array.$(hostname).[0-9]*.pfw; fi
 '
 
 test_expect_success 'c binding: smoketest3 runs ok in default' '
     ../smoketest3 &&
-    rm perfflow.$(hostname).[0-9]*.pfw
+    rm perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest3' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest3 &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw &&
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then rm perfflow.$(hostname).[0-9]*.pfw; fi
+    ! test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then rm perfflow.array.$(hostname).[0-9]*.pfw; fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest3' '
     PERFFLOW_OPTIONS="log-enable=True" ../smoketest3 &&
-    test -f perfflow.$(hostname).[0-9]*.pfw &&
-    rm perfflow.$(hostname).[0-9]*.pfw
+    test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+    rm perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 if test -f ../smoketest_MT; then
     test_expect_success 'c binding: smoketest_MT runs ok in default' '
         ../smoketest_MT &&
-        rm perfflow.$(hostname).[0-9]*.pfw
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     '
 
     test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_MT' '
         PERFFLOW_OPTIONS="log-enable=False" ../smoketest_MT &&
-        ! test -f perfflow.$(hostname).[0-9]*.pfw &&
-        if test -f perfflow.$(hostname).[0-9]*.pfw; then rm perfflow.$(hostname).[0-9]*.pfw; fi
+        ! test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+        if test -f perfflow.array.$(hostname).[0-9]*.pfw; then rm perfflow.array.$(hostname).[0-9]*.pfw; fi
     '
 
     test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest_MT' '
         PERFFLOW_OPTIONS="log-enable=True" ../smoketest_MT &&
-        test -f perfflow.$(hostname).[0-9]*.pfw &&
-        rm perfflow.$(hostname).[0-9]*.pfw
+        test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     '
 else
     say "Skipping multithreaded smoketests...disabled in the build."
@@ -207,19 +207,19 @@ fi
 if test -f ../smoketest_MPI; then
     test_expect_success 'c binding: smoketest_MPI runs ok in default' '
         mpirun -n 2 ../smoketest_MPI &&
-        rm perfflow.$(hostname).[0-9]*.pfw
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     '
 
     test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_MPI' '
         PERFFLOW_OPTIONS="log-enable=False"  mpirun -n 2 ../smoketest_MPI &&
-        test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -eq 0 &&
-        if test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -gt 0; then rm -f perfflow.$(hostname).[0-9]*.pfw; fi
+        test `ls -1 perfflow.array.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -eq 0 &&
+        if test `ls -1 perfflow.array.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -gt 0; then rm -f perfflow.array.$(hostname).[0-9]*.pfw; fi
     '
 
     test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest_MPI' '
         PERFFLOW_OPTIONS="log-enable=True"  mpirun -n 2 ../smoketest_MPI &&
-        test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -eq 2 &&
-        rm perfflow.$(hostname).[0-9]*.pfw
+        test `ls -1 perfflow.array.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -eq 2 &&
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     '
 else
     say "Skipping MPI smoketests...disabled in the build."
@@ -227,18 +227,24 @@ fi
 
 test_expect_success 'PERFFLOW_OPTIONS: use compact format smoketest' '
     PERFFLOW_OPTIONS="log-event=compact" ../smoketest &&
-    sanity_check_compact ./perfflow.$(hostname).[0-9]*.pfw &&
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    sanity_check_compact ./perfflow.array.$(hostname).[0-9]*.pfw &&
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: use verbose (default) format smoketest' '
     PERFFLOW_OPTIONS="log-event=verbose" ../smoketest &&
-    sanity_check ./perfflow.$(hostname).[0-9]*.pfw &&
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    sanity_check ./perfflow.array.$(hostname).[0-9]*.pfw &&
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: output object format smoketest' '
+    PERFFLOW_OPTIONS="log-enable=True:log-format=object" ../smoketest &&
+    test -f perfflow.object.$(hostname).[0-9]*.pfw &&
+    rm perfflow.object.$(hostname).[0-9]*.pfw
 '
 
 if test -f ../smoketest_cuda; then
@@ -270,7 +276,7 @@ fi
 
 test_expect_success 'c binding: smoketest_class runs ok in default' '
     ../smoketest_class &&
-    rm perfflow.$(hostname).[0-9]*.pfw
+    rm perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_done

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -41,6 +41,8 @@ def cannonicalize_perfflow_options():
         perfflow_options["cpu-mem-usage"] = "False"
     if perfflow_options.get("log-event") is None:
         perfflow_options["log-event"] = "Verbose"
+    if perfflow_options.get("log-format") is None:
+        perfflow_options["log-format"] = "Array"
 
 
 def parse_perfflow_options():
@@ -130,6 +132,8 @@ class ChromeTracingAdvice:
     #             instance-path: hierarchical component path
     #             hostname: name of the host where this process is running
     #             pid: process id
+    # To toggle output format (default: log-format=Array)
+    #     PERFFLOW_OPTIONS="log-format=Array|Object"
     # To change the directory in which the log file is created
     #     PERFFLOW_OPTIONS="log-dir=DIR"
     # To disable logging (default: log-enable=True)
@@ -160,6 +164,14 @@ class ChromeTracingAdvice:
             )
 
     fn += ".pfw"
+
+    log_format = perfflow_options["log-format"]
+    if log_format in ["Array"]:
+        array_format = True
+    elif log_format == "Object":
+        array_format = False
+    else:
+        raise ValueError("perfflow invalid option: log-format=[Array|Object]")
 
     log_dir = perfflow_options["log-dir"]
     if log_dir is not None:

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -250,7 +250,10 @@ class ChromeTracingAdvice:
         except KeyError:
             raise ValueError("Invalid pointcut: {}".format(pointcut))
         event = cls.create_sync_event(*args, phase, **kwargs)
-        cls.__flush_log(json.dumps(event) + ",")
+        if ChromeTracingAdvice.array_format == True:
+            cls.__flush_log(json.dumps(event) + ",")
+        else:
+            cls.__flush_log("    " + json.dumps(event) + ",")
 
     async_pointcut_phase_map = {"before": "b", "instant": "n", "after": "e"}
 
@@ -261,7 +264,10 @@ class ChromeTracingAdvice:
         except KeyError:
             raise ValueError("Invalid pointcut: {}".format(pointcut))
         event = cls.create_async_event(*args, phase, **kwargs)
-        cls.__flush_log(json.dumps(event) + ",")
+        if ChromeTracingAdvice.array_format == True:
+            cls.__flush_log(json.dumps(event) + ",")
+        else:
+            cls.__flush_log("    " + json.dumps(event) + ",")
 
     @classmethod
     def __create_event_from_func(cls, func):
@@ -278,9 +284,13 @@ class ChromeTracingAdvice:
             formatter = logging.Formatter("%(message)s")
             fh.setFormatter(formatter)
             ChromeTracingAdvice.logger.addHandler(fh)
-            ChromeTracingAdvice.logger.debug("[")
-            if ChromeTracingAdvice.array_format == False:
-                ChromeTracingAdvice.logger.debug("\"traceEvents\": [")
+            if ChromeTracingAdvice.array_format == True:
+                ChromeTracingAdvice.logger.debug("[")
+            else:
+                ChromeTracingAdvice.logger.debug("{")
+                ChromeTracingAdvice.logger.debug("  \"displayTimeUnit\": \"us\",")
+                ChromeTracingAdvice.logger.debug("  \"otherData\": {},")
+                ChromeTracingAdvice.logger.debug("  \"traceEvents\": [")
         ChromeTracingAdvice.logger.debug(s)
 
     @staticmethod
@@ -295,7 +305,10 @@ class ChromeTracingAdvice:
             event["ts"] = event_ts
         if event_dur is not None:
             event["dur"] = event_dur
-        ChromeTracingAdvice.__flush_log(json.dumps(event) + ",")
+        if ChromeTracingAdvice.array_format == True:
+            ChromeTracingAdvice.__flush_log(json.dumps(event) + ",")
+        else:
+            ChromeTracingAdvice.__flush_log("    " + json.dumps(event) + ",")
         counter = counter + 1
         counter_mutex.release()
 
@@ -315,7 +328,10 @@ class ChromeTracingAdvice:
             event["ts"] = event_ts
         if event_dur is not None:
             event["dur"] = event_dur
-        ChromeTracingAdvice.__flush_log(json.dumps(event) + ",")
+        if ChromeTracingAdvice.array_format == True:
+            ChromeTracingAdvice.__flush_log(json.dumps(event) + ",")
+        else:
+            ChromeTracingAdvice.__flush_log("    " + json.dumps(event) + ",")
         counter = counter + 1
         counter_mutex.release()
 

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -250,7 +250,7 @@ class ChromeTracingAdvice:
         except KeyError:
             raise ValueError("Invalid pointcut: {}".format(pointcut))
         event = cls.create_sync_event(*args, phase, **kwargs)
-        if ChromeTracingAdvice.array_format == True:
+        if ChromeTracingAdvice.array_format:
             cls.__flush_log(json.dumps(event) + ",")
         else:
             cls.__flush_log("    " + json.dumps(event) + ",")
@@ -264,7 +264,7 @@ class ChromeTracingAdvice:
         except KeyError:
             raise ValueError("Invalid pointcut: {}".format(pointcut))
         event = cls.create_async_event(*args, phase, **kwargs)
-        if ChromeTracingAdvice.array_format == True:
+        if ChromeTracingAdvice.array_format:
             cls.__flush_log(json.dumps(event) + ",")
         else:
             cls.__flush_log("    " + json.dumps(event) + ",")
@@ -284,15 +284,15 @@ class ChromeTracingAdvice:
             formatter = logging.Formatter("%(message)s")
             fh.setFormatter(formatter)
             ChromeTracingAdvice.logger.addHandler(fh)
-            if ChromeTracingAdvice.array_format == True:
+            if ChromeTracingAdvice.array_format:
                 ChromeTracingAdvice.logger.debug("[")
             else:
                 ChromeTracingAdvice.logger.debug("{")
-                ChromeTracingAdvice.logger.debug("  \"displayTimeUnit\": \"us\",")
-                ChromeTracingAdvice.logger.debug("  \"otherData\": {")
+                ChromeTracingAdvice.logger.debug('  "displayTimeUnit": "us",')
+                ChromeTracingAdvice.logger.debug('  "otherData": {')
                 ChromeTracingAdvice.logger.debug("")
                 ChromeTracingAdvice.logger.debug("  },")
-                ChromeTracingAdvice.logger.debug("  \"traceEvents\": [")
+                ChromeTracingAdvice.logger.debug('  "traceEvents": [')
         ChromeTracingAdvice.logger.debug(s)
 
     @staticmethod
@@ -307,7 +307,7 @@ class ChromeTracingAdvice:
             event["ts"] = event_ts
         if event_dur is not None:
             event["dur"] = event_dur
-        if ChromeTracingAdvice.array_format == True:
+        if ChromeTracingAdvice.array_format:
             ChromeTracingAdvice.__flush_log(json.dumps(event) + ",")
         else:
             ChromeTracingAdvice.__flush_log("    " + json.dumps(event) + ",")
@@ -330,7 +330,7 @@ class ChromeTracingAdvice:
             event["ts"] = event_ts
         if event_dur is not None:
             event["dur"] = event_dur
-        if ChromeTracingAdvice.array_format == True:
+        if ChromeTracingAdvice.array_format:
             ChromeTracingAdvice.__flush_log(json.dumps(event) + ",")
         else:
             ChromeTracingAdvice.__flush_log("    " + json.dumps(event) + ",")

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -132,8 +132,6 @@ class ChromeTracingAdvice:
     #             instance-path: hierarchical component path
     #             hostname: name of the host where this process is running
     #             pid: process id
-    # To toggle output format (default: log-format=Array)
-    #     PERFFLOW_OPTIONS="log-format=Array|Object"
     # To change the directory in which the log file is created
     #     PERFFLOW_OPTIONS="log-dir=DIR"
     # To disable logging (default: log-enable=True)
@@ -142,6 +140,8 @@ class ChromeTracingAdvice:
     #     PERFFLOW_OPTIONS="cpu-mem-usage=True"
     # To collect B (begin) and E (end) events as single X (complete) duration event (default: log-event=Verbose)
     #     PERFFLOW_OPTIONS="log-event=Compact"
+    # To toggle output format (default: log-format=Array)
+    #     PERFFLOW_OPTIONS="log-format=Array|Object"
     # You can combine the options in colon (:) delimited format
 
     parse_perfflow_options()
@@ -163,15 +163,17 @@ class ChromeTracingAdvice:
                 "perfflow warning: unknown option param={}".format(inc), file=sys.stderr
             )
 
-    fn += ".pfw"
-
     log_format = perfflow_options["log-format"]
-    if log_format in ["Array"]:
+    if log_format in ["Array", "array", "ARRAY"]:
         array_format = True
-    elif log_format == "Object":
+        fn += "ARRAY"
+    elif log_format in ["Object", "object", "OBJECT"]:
         array_format = False
+        fn += "OBJECT"
     else:
         raise ValueError("perfflow invalid option: log-format=[Array|Object]")
+
+    fn += ".pfw"
 
     log_dir = perfflow_options["log-dir"]
     if log_dir is not None:

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -149,6 +149,17 @@ class ChromeTracingAdvice:
     set_perfflow_instance_path(inst_path)
 
     fn = "perfflow"
+
+    log_format = perfflow_options["log-format"]
+    if log_format in ["Array", "array", "ARRAY"]:
+        array_format = True
+        fn += ".array"
+    elif log_format in ["Object", "object", "OBJECT"]:
+        array_format = False
+        fn += ".object"
+    else:
+        raise ValueError("perfflow invalid option: log-format=[Array|Object]")
+
     for inc in perfflow_options["log-filename-include"].split(","):
         if inc == "name":
             fn += "." + perfflow_options["name"]
@@ -162,16 +173,6 @@ class ChromeTracingAdvice:
             print(
                 "perfflow warning: unknown option param={}".format(inc), file=sys.stderr
             )
-
-    log_format = perfflow_options["log-format"]
-    if log_format in ["Array", "array", "ARRAY"]:
-        array_format = True
-        fn += "-ARRAY"
-    elif log_format in ["Object", "object", "OBJECT"]:
-        array_format = False
-        fn += "-OBJECT"
-    else:
-        raise ValueError("perfflow invalid option: log-format=[Array|Object]")
 
     fn += ".pfw"
 

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -289,7 +289,9 @@ class ChromeTracingAdvice:
             else:
                 ChromeTracingAdvice.logger.debug("{")
                 ChromeTracingAdvice.logger.debug("  \"displayTimeUnit\": \"us\",")
-                ChromeTracingAdvice.logger.debug("  \"otherData\": {},")
+                ChromeTracingAdvice.logger.debug("  \"otherData\": {")
+                ChromeTracingAdvice.logger.debug("")
+                ChromeTracingAdvice.logger.debug("  },")
                 ChromeTracingAdvice.logger.debug("  \"traceEvents\": [")
         ChromeTracingAdvice.logger.debug(s)
 

--- a/src/python/perfflowaspect/advice_chrome.py
+++ b/src/python/perfflowaspect/advice_chrome.py
@@ -166,10 +166,10 @@ class ChromeTracingAdvice:
     log_format = perfflow_options["log-format"]
     if log_format in ["Array", "array", "ARRAY"]:
         array_format = True
-        fn += "ARRAY"
+        fn += "-ARRAY"
     elif log_format in ["Object", "object", "OBJECT"]:
         array_format = False
-        fn += "OBJECT"
+        fn += "-OBJECT"
     else:
         raise ValueError("perfflow invalid option: log-format=[Array|Object]")
 
@@ -279,6 +279,8 @@ class ChromeTracingAdvice:
             fh.setFormatter(formatter)
             ChromeTracingAdvice.logger.addHandler(fh)
             ChromeTracingAdvice.logger.debug("[")
+            if ChromeTracingAdvice.array_format == False:
+                ChromeTracingAdvice.logger.debug("\"traceEvents\": [")
         ChromeTracingAdvice.logger.debug(s)
 
     @staticmethod

--- a/src/python/test/t0001-pybinding-basic.t
+++ b/src/python/test/t0001-pybinding-basic.t
@@ -45,167 +45,173 @@ test_expect_success 'py binding: smoketest runs ok in default' '
 '
 
 test_expect_success 'py binding: ctf file appears good' '
-    sanity_check perfflow.$(hostname).[0-9]*.pfw &&
-    rm perfflow.$(hostname).[0-9]*.pfw
+    sanity_check perfflow.array.$(hostname).[0-9]*.pfw &&
+    rm perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: log-dir works' '
     PERFFLOW_OPTIONS="log-dir=./logdir" ../smoketest.py &&
-    sanity_check ./logdir/perfflow.$(hostname).[0-9]*.pfw &&
-    rm ./logdir/perfflow.$(hostname).[0-9]*.pfw
+    sanity_check ./logdir/perfflow.array.$(hostname).[0-9]*.pfw &&
+    rm ./logdir/perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: name can be included in filename' '
     PERFFLOW_OPTIONS="name=mycomponent:log-filename-include=name" \
 	../smoketest.py &&
-    test -f perfflow.mycomponent.pfw &&
-    sanity_check perfflow.mycomponent.pfw &&
-    rm perfflow.mycomponent.pfw
+    test -f perfflow.array.mycomponent.pfw &&
+    sanity_check perfflow.array.mycomponent.pfw &&
+    rm perfflow.array.mycomponent.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: instance-path included in filename' '
     PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
-    test -f perfflow.{[a-f0-9]*}.pfw &&
-    sanity_check perfflow.{[a-f0-9]*}.pfw &&
-    rm perfflow.{[a-f0-9]*}.pfw
+    test -f perfflow.array.{[a-f0-9]*}.pfw &&
+    sanity_check perfflow.array.{[a-f0-9]*}.pfw &&
+    rm perfflow.array.{[a-f0-9]*}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: filename includes all' '
     PERFFLOW_OPTIONS="log-filename-include=name,instance-path,hostname,pid" \
 	../smoketest.py &&
-    test -f perfflow.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw &&
-    sanity_check perfflow.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw &&
-    rm perfflow.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw
+    test -f perfflow.array.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw &&
+    sanity_check perfflow.array.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw &&
+    rm perfflow.array.generic.{[a-f0-9]*}.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: filename includes all in correct order' '
     PERFFLOW_OPTIONS="log-filename-include=hostname,instance-path,pid,name" \
 	../smoketest.py &&
-    test -f perfflow.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw &&
-    sanity_check perfflow.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw &&
-    rm perfflow.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw
+    test -f perfflow.array.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw &&
+    sanity_check perfflow.array.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw &&
+    rm perfflow.array.$(hostname).{[a-f0-9]*}.[0-9]*.generic.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: SLURM supported' '
     SLURM_JOB_ID=123456 SLURM_STEP_ID=1 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
     sha1=$(echo -n "123456.1" | sha1sum | awk "{print \$1}" | cut -c1-8) &&
-    test -f perfflow.{${sha1}}.pfw &&
-    sanity_check perfflow.{${sha1}}.pfw &&
-    rm perfflow.{${sha1}}.pfw
+    test -f perfflow.array.{${sha1}}.pfw &&
+    sanity_check perfflow.array.{${sha1}}.pfw &&
+    rm perfflow.array.{${sha1}}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: LSF supported' '
     LSB_JOBID=123456 LS_JOBPID=1 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
     sha1=$(echo -n "123456.1" | sha1sum | awk "{print \$1}" | cut -c1-8) &&
-    test -f perfflow.{${sha1}}.pfw &&
-    sanity_check perfflow.{${sha1}}.pfw &&
-    rm perfflow.{${sha1}}.pfw
+    test -f perfflow.array.{${sha1}}.pfw &&
+    sanity_check perfflow.array.{${sha1}}.pfw &&
+    rm perfflow.array.{${sha1}}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: SLURM_JOB_ID + STEP_ID must be given' '
     SLURM_JOB_ID=123456 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
     sha1=$(echo -n "1" | sha1sum | awk "{print \$1}" | cut -c1-8) &&
-    test -f perfflow.{${sha1}}.pfw &&
-    sanity_check perfflow.{${sha1}}.pfw &&
-    rm perfflow.{${sha1}}.pfw
+    test -f perfflow.array.{${sha1}}.pfw &&
+    sanity_check perfflow.array.{${sha1}}.pfw &&
+    rm perfflow.array.{${sha1}}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: LSB_JOBID + LS_JOBPID must be given' '
     LSB_JOB_ID=123456 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
     sha1=$(echo -n "1" | sha1sum | awk "{print \$1}" | cut -c1-8) &&
-    test -f perfflow.{${sha1}}.pfw &&
-    sanity_check perfflow.{${sha1}}.pfw &&
-    rm perfflow.{${sha1}}.pfw
+    test -f perfflow.array.{${sha1}}.pfw &&
+    sanity_check perfflow.array.{${sha1}}.pfw &&
+    rm perfflow.array.{${sha1}}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: Flux supported' '
     FLUX_JOB_ID=123456 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
-    test -f perfflow.{123456}.pfw &&
-    sanity_check perfflow.{123456}.pfw &&
-    rm perfflow.{123456}.pfw
+    test -f perfflow.array.{123456}.pfw &&
+    sanity_check perfflow.array.{123456}.pfw &&
+    rm perfflow.array.{123456}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: Flux f58-encoded jobid supported' '
     FLUX_JOB_ID=ƒeF9QZG3 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
-    test -f perfflow.{ƒeF9QZG3}.pfw &&
-    sanity_check perfflow.{ƒeF9QZG3}.pfw &&
-    rm perfflow.{ƒeF9QZG3}.pfw
+    test -f perfflow.array.{ƒeF9QZG3}.pfw &&
+    sanity_check perfflow.array.{ƒeF9QZG3}.pfw &&
+    rm perfflow.array.{ƒeF9QZG3}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: nested instance-path supported' '
     PERFFLOW_INSTANCE_PATH=fffffff.444444 FLUX_JOB_ID=123456 \
 PERFFLOW_OPTIONS="log-filename-include=instance-path" ../smoketest.py &&
-    test -f perfflow.{fffffff.444444.123456}.pfw &&
-    sanity_check perfflow.{fffffff.444444.123456}.pfw &&
-    rm perfflow.{fffffff.444444.123456}.pfw
+    test -f perfflow.array.{fffffff.444444.123456}.pfw &&
+    sanity_check perfflow.array.{fffffff.444444.123456}.pfw &&
+    rm perfflow.array.{fffffff.444444.123456}.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest.py &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.array.$(hostname).[0-9]*.pfw
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest' '
     PERFFLOW_OPTIONS="log-enable=True" ../smoketest.py &&
-    test -f perfflow.$(hostname).[0-9]*.pfw &&
-    rm perfflow.$(hostname).[0-9]*.pfw
+    test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+    rm perfflow.array.$(hostname).[0-9]*.pfw
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_future' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future.py &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.array.$(hostname).[0-9]*.pfw
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_future2' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future2.py &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.array.$(hostname).[0-9]*.pfw
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_direct' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_direct.py &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.array.$(hostname).[0-9]*.pfw
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_future_direct' '
     PERFFLOW_OPTIONS="log-enable=False" ../smoketest_future_direct.py &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    ! test -f perfflow.array.$(hostname).[0-9]*.pfw
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: use compact format smoketest' '
     PERFFLOW_OPTIONS="log-event=compact" ../smoketest.py &&
-    sanity_check_compact ./perfflow.$(hostname).[0-9]*.pfw &&
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    sanity_check_compact ./perfflow.array.$(hostname).[0-9]*.pfw &&
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
 '
 
 test_expect_success 'PERFFLOW_OPTIONS: use verbose (default) format smoketest' '
     PERFFLOW_OPTIONS="log-event=verbose" ../smoketest.py &&
-    sanity_check ./perfflow.$(hostname).[0-9]*.pfw &&
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then
-        rm perfflow.$(hostname).[0-9]*.pfw
+    sanity_check ./perfflow.array.$(hostname).[0-9]*.pfw &&
+    if test -f perfflow.array.$(hostname).[0-9]*.pfw; then
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     fi
+'
+
+test_expect_success 'PERFFLOW_OPTIONS: output object format smoketest' '
+    PERFFLOW_OPTIONS="log-enable=True:log-format=object" ../smoketest.py &&
+    test -f perfflow.object.$(hostname).[0-9]*.pfw &&
+    rm perfflow.object.$(hostname).[0-9]*.pfw
 '
 
 # Run cuda tests if NVIDIA GPU is present
@@ -213,19 +219,19 @@ lspci=$(lspci | grep -i nvidia 2>/dev/null)
 if [ -n "${lspci}" ]; then
     test_expect_success 'py binding: smoketest_cuda runs ok in default' '
         ../smoketest_cuda.py &&
-        rm perfflow.$(hostname).[0-9]*.pfw
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     '
 
     test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_cuda' '
         PERFFLOW_OPTIONS="log-enable=False" ../smoketest_cuda.py &&
-        ! test -f perfflow.$(hostname).[0-9]*.pfw &&
-        if test -f perfflow.$(hostname).[0-9]*.pfw; then rm perfflow.$(hostname).[0-9]*.pfw; fi
+        ! test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+        if test -f perfflow.array.$(hostname).[0-9]*.pfw; then rm perfflow.array.$(hostname).[0-9]*.pfw; fi
     '
 
     test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest_cuda' '
         PERFFLOW_OPTIONS="log-enable=True" ../smoketest_cuda.py &&
-        test -f perfflow.$(hostname).[0-9]*.pfw &&
-        rm perfflow.$(hostname).[0-9]*.pfw
+        test -f perfflow.array.$(hostname).[0-9]*.pfw &&
+        rm perfflow.array.$(hostname).[0-9]*.pfw
     '
 else
     say "Skipping CUDA smoketests...NVIDIA GPU not found."


### PR DESCRIPTION
Fixes #123 

TODO:
- [x] CTF format specifies valid values for `displayTimeUnit` as ms or ns. But in PFA, we are converting to microsec. Please check how the value of displayTimeUnit impacts the visualization in Perfetto (if at all). Then this is ready for merge.

Viewable in perfetto (without closing brackets):
```
{
  "displayTimeUnit": "us",
  "otherData": {

  },
  "traceEvents": [
    {"name": "foo", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174687410.2, "ph": "B"},
    {"name": "bar", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174689621.8, "ph": "B"},
    {"name": "bas", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174690776.0, "ph": "B"},
    {"name": "bas", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174690855.5, "ph": "E"},
    {"name": "bar", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174690925.0, "ph": "E"},
    {"name": "foo", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174690992.2, "ph": "E"},
    {"name": "foo", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174691069.5, "ph": "B"},
    {"name": "bar", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174692209.5, "ph": "B"},
    {"name": "bas", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174693350.2, "ph": "B"},
    {"name": "bas", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174693426.2, "ph": "E"},
    {"name": "bar", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174693492.8, "ph": "E"},
    {"name": "foo", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174693558.8, "ph": "E"},
    {"name": "foo", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174693634.5, "ph": "B"},
    {"name": "bar", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174694773.0, "ph": "B"},
    {"name": "bas", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174695913.5, "ph": "B"},
    {"name": "bas", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174695988.0, "ph": "E"},
    {"name": "bar", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174696054.5, "ph": "E"},
    {"name": "foo", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174696120.2, "ph": "E"},
    {"name": "foo", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174696195.2, "ph": "B"},
    {"name": "bar", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174697334.5, "ph": "B"},
    {"name": "bas", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174698474.8, "ph": "B"},
    {"name": "bas", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174698551.8, "ph": "E"},
    {"name": "bar", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174698618.5, "ph": "E"},
    {"name": "foo", "cat": "__main__", "pid": 74101, "tid": 74101, "ts": 1712616174698683.8, "ph": "E"},
```