### PR TITLE
bugfix: smoketests configure build

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -7,6 +7,40 @@ jobs:
   build-c:
     name: check c bindings
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        config: [boilerplate, release, debug_cuda_only, debug_mpi_only, debug_threads_only]
+
+        include:
+          - config: boilerplate
+            PERFFLOWASPECT_WITH_CUDA: ON
+            PERFFLOWASPECT_WITH_MPI: ON
+            PERFFLOWASPECT_WITH_MULTITHREADS: ON
+            CMAKE_BUILD_TYPE: Debug
+
+          - config: release
+            PERFFLOWASPECT_WITH_CUDA: ON
+            PERFFLOWASPECT_WITH_MPI: ON
+            PERFFLOWASPECT_WITH_MULTITHREADS: ON
+            CMAKE_BUILD_TYPE: Release
+
+          - config: debug_cuda_only
+            PERFFLOWASPECT_WITH_CUDA: ON
+            PERFFLOWASPECT_WITH_MPI: OFF
+            PERFFLOWASPECT_WITH_MULTITHREADS: OFF
+            CMAKE_BUILD_TYPE: Debug
+
+          - config: debug_mpi_only
+            PERFFLOWASPECT_WITH_CUDA: OFF
+            PERFFLOWASPECT_WITH_MPI: ON
+            PERFFLOWASPECT_WITH_MULTITHREADS: OFF
+            CMAKE_BUILD_TYPE: Debug
+
+          - config: debug_threads_only
+            PERFFLOWASPECT_WITH_CUDA: OFF
+            PERFFLOWASPECT_WITH_MPI: OFF
+            PERFFLOWASPECT_WITH_MULTITHREADS: ON
+            CMAKE_BUILD_TYPE: Debug
 
     steps:
       # Checkout PerfFlowAspect repository under $GITHUB_WORKSPACE
@@ -34,7 +68,11 @@ jobs:
           cd src/c
           mkdir build install
           cd build
-          export CMAKE_OPTS="-DCMAKE_CXX_COMPILER=clang++ -DLLVM_DIR=/usr/lib/llvm-10/cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install"
+          export CMAKE_OPTS="-DCMAKE_CXX_COMPILER=clang++ -DLLVM_DIR=/usr/lib/llvm-10/cmake -DCMAKE_INSTALL_PREFIX=../install"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${{matrix.CMAKE_BUILD_TYPE}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DPERFFLOWASPECT_WITH_CUDA=${{matrix.PERFFLOWASPECT_WITH_CUDA}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DPERFFLOWASPECT_WITH_MPI=${{matrix.PERFFLOWASPECT_WITH_MPI}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DPERFFLOWASPECT_WITH_MULTITHREADS=${{matrix.PERFFLOWASPECT_WITH_MULTITHREADS}}"
           echo -e ${CMAKE_OPTS}
           cmake ${CMAKE_OPTS} ..
           # build

--- a/src/c/cmake/thirdparty/FindMPI.cmake
+++ b/src/c/cmake/thirdparty/FindMPI.cmake
@@ -1,5 +1,3 @@
 find_package(MPI REQUIRED)
 
-if(PERFFLOWASPECT_WITH_MPI)
-    message(STATUS "Building MPI smoketest (PERFFLOWASPECT_WITH_MPI == ON)")
-endif()
+message(STATUS "Building MPI smoketest (PERFFLOWASPECT_WITH_MPI == ON)")

--- a/src/c/cmake/thirdparty/FindThreads.cmake
+++ b/src/c/cmake/thirdparty/FindThreads.cmake
@@ -1,5 +1,3 @@
 find_package(Threads REQUIRED)
 
-if(PERFFLOWASPECT_WITH_MULTITHREADS)
-    message(STATUS "Building multi-threaded smoketest (PERFFLOWASPECT_WITH_MULTITHREADS == ON)")
-endif()
+message(STATUS "Building multi-threaded smoketest (PERFFLOWASPECT_WITH_MULTITHREADS == ON)")

--- a/src/c/test/CMakeLists.txt
+++ b/src/c/test/CMakeLists.txt
@@ -3,28 +3,35 @@ set(SMOKETESTS
     smoketest2
     smoketest3
     smoketest_class
-    smoketest_MPI
-    smoketest_MT
 )
 
-if(MPI_FOUND)
-    include_directories(${MPI_INCLUDE_PATH})
-endif()
-
 set(perfflow_deps "-L../runtime -lperfflow_runtime" OpenSSL::Crypto)
-set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 message(STATUS "Adding CXX unit tests")
 foreach(TEST ${SMOKETESTS})
     message(STATUS " [*] Adding test: ${TEST}")
     add_executable(${TEST} ${TEST}.cpp)
-    target_link_libraries(${TEST} ${MPI_LIBRARIES})
-    target_link_libraries(${TEST} pthread)
     set_source_files_properties(${TEST}.cpp COMPILE_FLAGS "-Xclang -load -Xclang ../weaver/weave/libWeavePass.so -fPIC")
     target_link_libraries(${TEST} ${perfflow_deps})
 endforeach()
 
-if(CUDA_FOUND)
+if(PERFFLOWASPECT_WITH_MULTITHREADS)
+    message(STATUS " [*] Adding test: smoketest_MT")
+    add_executable(smoketest_MT smoketest_MT.cpp)
+    set_source_files_properties(${TEST}.cpp COMPILE_FLAGS "-Xclang -load -Xclang ../weaver/weave/libWeavePass.so -fPIC")
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    target_link_libraries(smoketest_MT ${perfflow_deps} pthread)
+endif()
+
+if(PERFFLOWASPECT_WITH_MPI)
+    message(STATUS " [*] Adding test: smoketest_MPI")
+    add_executable(smoketest_MPI smoketest_MPI.cpp)
+    set_source_files_properties(smoketest_MPI.cpp COMPILE_FLAGS "-Xclang -load -Xclang ../weaver/weave/libWeavePass.so -fPIC")
+    include_directories(${MPI_INCLUDE_PATH})
+    target_link_libraries(smoketest_MPI ${perfflow_deps} ${MPI_LIBRARIES})
+endif()
+
+if(PERFFLOWASPECT_WITH_CUDA)
     message(STATUS " [*] Adding test: smoketest_cuda")
     set(CUDA_NVCC_FLAGS  "-ccbin ${CMAKE_CXX_COMPILER} -Xcompiler=-Xclang -Xcompiler=-load -Xcompiler=-Xclang -Xcompiler=../../../weaver/weave/libWeavePass.so")
     cuda_add_executable(smoketest_cuda smoketest_cuda_wrapper.cpp smoketest_cuda_kernel.cu)

--- a/src/c/test/t0001-cbinding-basic.t.in
+++ b/src/c/test/t0001-cbinding-basic.t.in
@@ -183,39 +183,47 @@ test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest3' '
     rm perfflow.$(hostname).[0-9]*.pfw
 '
 
-test_expect_success 'c binding: smoketest_MT runs ok in default' '
-    ../smoketest_MT &&
-    rm perfflow.$(hostname).[0-9]*.pfw
-'
+if test -f ../smoketest_MT; then
+    test_expect_success 'c binding: smoketest_MT runs ok in default' '
+        ../smoketest_MT &&
+        rm perfflow.$(hostname).[0-9]*.pfw
+    '
 
-test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_MT' '
-    PERFFLOW_OPTIONS="log-enable=False" ../smoketest_MT &&
-    ! test -f perfflow.$(hostname).[0-9]*.pfw &&
-    if test -f perfflow.$(hostname).[0-9]*.pfw; then rm perfflow.$(hostname).[0-9]*.pfw; fi
-'
+    test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_MT' '
+        PERFFLOW_OPTIONS="log-enable=False" ../smoketest_MT &&
+        ! test -f perfflow.$(hostname).[0-9]*.pfw &&
+        if test -f perfflow.$(hostname).[0-9]*.pfw; then rm perfflow.$(hostname).[0-9]*.pfw; fi
+    '
 
-test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest_MT' '
-    PERFFLOW_OPTIONS="log-enable=True" ../smoketest_MT &&
-    test -f perfflow.$(hostname).[0-9]*.pfw &&
-    rm perfflow.$(hostname).[0-9]*.pfw
-'
+    test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest_MT' '
+        PERFFLOW_OPTIONS="log-enable=True" ../smoketest_MT &&
+        test -f perfflow.$(hostname).[0-9]*.pfw &&
+        rm perfflow.$(hostname).[0-9]*.pfw
+    '
+else
+    say "Skipping multithreaded smoketests...disabled in the build."
+fi
 
-test_expect_success 'c binding: smoketest_MPI runs ok in default' '
-    mpirun -n 2 ../smoketest_MPI &&
-    rm perfflow.$(hostname).[0-9]*.pfw
-'
+if test -f ../smoketest_MPI; then
+    test_expect_success 'c binding: smoketest_MPI runs ok in default' '
+        mpirun -n 2 ../smoketest_MPI &&
+        rm perfflow.$(hostname).[0-9]*.pfw
+    '
 
-test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_MPI' '
-    PERFFLOW_OPTIONS="log-enable=False"  mpirun -n 2 ../smoketest_MPI &&
-    test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -eq 0 &&
-    if test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -gt 0; then rm -f perfflow.$(hostname).[0-9]*.pfw; fi
-'
+    test_expect_success 'PERFFLOW_OPTIONS: disable logging smoketest_MPI' '
+        PERFFLOW_OPTIONS="log-enable=False"  mpirun -n 2 ../smoketest_MPI &&
+        test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -eq 0 &&
+        if test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -gt 0; then rm -f perfflow.$(hostname).[0-9]*.pfw; fi
+    '
 
-test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest_MPI' '
-    PERFFLOW_OPTIONS="log-enable=True"  mpirun -n 2 ../smoketest_MPI &&
-    test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -eq 2 &&
-    rm perfflow.$(hostname).[0-9]*.pfw
-'
+    test_expect_success 'PERFFLOW_OPTIONS: enable logging smoketest_MPI' '
+        PERFFLOW_OPTIONS="log-enable=True"  mpirun -n 2 ../smoketest_MPI &&
+        test `ls -1 perfflow.$(hostname).[0-9]*.pfw 2>/dev/null | wc -l` -eq 2 &&
+        rm perfflow.$(hostname).[0-9]*.pfw
+    '
+else
+    say "Skipping MPI smoketests...disabled in the build."
+fi
 
 test_expect_success 'PERFFLOW_OPTIONS: use compact format smoketest' '
     PERFFLOW_OPTIONS="log-event=compact" ../smoketest &&


### PR DESCRIPTION
We've added new CMake variables to enable building of certain smoketests. This fixes the build system such that turning on/off these variables adds or removes the target smoketest from the build.