### PR TITLE
build CUDA smoketest if CUDA is found

### DIFF
--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -2,11 +2,6 @@ cmake_minimum_required(VERSION 3.12)
 
 project(PerfFlowAspect VERSION "0.1.0")
 
-# Build Options
-option(PERFFLOWASPECT_WITH_CUDA "Build CUDA smoketest" ON)
-option(PERFFLOWASPECT_WITH_MPI "Build MPI smoketest" ON)
-option(PERFFLOWASPECT_WITH_MULTITHREADS "Build multi-threaded smoketest" ON)
-
 # Fail if using Clang < 9.0
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # require at least Clang 9.0

--- a/src/c/test/CMakeLists.txt
+++ b/src/c/test/CMakeLists.txt
@@ -15,6 +15,17 @@ foreach(TEST ${SMOKETESTS})
     target_link_libraries(${TEST} ${perfflow_deps})
 endforeach()
 
+# Build Options
+option(PERFFLOWASPECT_WITH_MULTITHREADS "Build multi-threaded smoketest" ON)
+find_package(CUDA QUIET)
+if(CUDA_FOUND)
+    option(PERFFLOWASPECT_WITH_CUDA "Build CUDA smoketest" ON)
+endif()
+find_package(MPI QUIET)
+if(MPI_FOUND)
+    option(PERFFLOWASPECT_WITH_MPI "Build MPI smoketest" ON)
+endif()
+
 if(PERFFLOWASPECT_WITH_MULTITHREADS)
     message(STATUS " [*] Adding test: smoketest_MT")
     add_executable(smoketest_MT smoketest_MT.cpp)


### PR DESCRIPTION
Building CUDA smoketests are ON by default. This PR looks for the CUDA package (quietly, so no errors to stdout if not found) and turns this off if the package is not found.