### PR TITLE
File Overhead

### DIFF
--- a/src/c/host-configs/turing.cmake
+++ b/src/c/host-configs/turing.cmake
@@ -1,0 +1,13 @@
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+set(CMAKE_CXX_COMPILER "/cm/shared/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-12.1.0/llvm-14.0.6-issizheik6vcv6owwk7pk45xccoaaghy/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/cm/shared/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-12.1.0/llvm-14.0.6-issizheik6vcv6owwk7pk45xccoaaghy/bin/clang" CACHE PATH "")
+set(LLVM_DIR "/cm/shared/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-12.1.0/llvm-14.0.6-issizheik6vcv6owwk7pk45xccoaaghy/lib/cmake/llvm" CACHE PATH "")

--- a/src/c/host-configs/turing.cmake
+++ b/src/c/host-configs/turing.cmake
@@ -11,3 +11,4 @@
 set(CMAKE_CXX_COMPILER "/cm/shared/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-12.1.0/llvm-14.0.6-issizheik6vcv6owwk7pk45xccoaaghy/bin/clang++" CACHE PATH "")
 set(CMAKE_C_COMPILER "/cm/shared/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-12.1.0/llvm-14.0.6-issizheik6vcv6owwk7pk45xccoaaghy/bin/clang" CACHE PATH "")
 set(LLVM_DIR "/cm/shared/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-12.1.0/llvm-14.0.6-issizheik6vcv6owwk7pk45xccoaaghy/lib/cmake/llvm" CACHE PATH "")
+set(CMAKE_CXX_FLAGS "-flegacy-pass-manager" CACHE STRING "")

--- a/src/c/parser/perfflow_parser.cpp
+++ b/src/c/parser/perfflow_parser.cpp
@@ -1,5 +1,5 @@
 /************************************************************\
- * Copyright 2021 Lawrence Livermore National Secu#rity, LLC
+ * Copyright 2021 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
  *
  * This file is part of the Flux resource manager framework.

--- a/src/c/parser/perfflow_parser.cpp
+++ b/src/c/parser/perfflow_parser.cpp
@@ -1,5 +1,5 @@
 /************************************************************\
- * Copyright 2021 Lawrence Livermore National Security, LLC
+ * Copyright 2021 Lawrence Livermore National Secu#rity, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
  *
  * This file is part of the Flux resource manager framework.

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -780,7 +780,7 @@ int advice_chrome_tracing_t::before(const char *module,
             /* initialize the identifier and statistics structures */
             m_statistics stats = {};
             m_identifier ident = {};
-            
+
             jtemp = json_object_get(event, "name");
             std::string my_name = json_string_value(jtemp);
             jtemp = json_object_get(event, "pid");
@@ -923,7 +923,7 @@ int advice_chrome_tracing_t::after(const char *module,
 
             /* statistics & timing calculations */
             prev_ts = stats_before.ts;
-            
+
             /* if collecting statistics, also collect at the End event */
             if (m_cpu_mem_usage_enable == 1) {
                 cpu_start = stats_before.cpu;
@@ -932,11 +932,11 @@ int advice_chrome_tracing_t::after(const char *module,
                 prev_ts = stats_before.ts;
 
             }
-            
+
             else if (m_compact_event_enable == 1) {
                 prev_ts = stats_before.ts;
             }
-            
+
             cpu_usage = cpu_usage - cpu_start;
             if (cpu_usage < 0.0001)
             {

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -792,7 +792,7 @@ int advice_chrome_tracing_t::before(const char *module,
             ident.name = my_name;
             ident.pid = my_pid;
             ident.tid = my_tid;
-            
+
             /* if logging, set statistics*/
             if (m_cpu_mem_usage_enable == 1)
             {
@@ -803,7 +803,7 @@ int advice_chrome_tracing_t::before(const char *module,
                 stats.cpu = cpu_start;
                 stats.wall = wall_start;
                 stats.mem = mem_start;
-                
+
             }
             stats.ts = my_ts; /* always collect the timestamp */
             m_around_stack[ident] = stats; /* map the statistics to identifier */
@@ -916,7 +916,8 @@ int advice_chrome_tracing_t::after(const char *module,
             ident.tid = my_tid;
 
             /* finds and sets the before statistics */
-            if (m_around_stack.find(ident) != m_around_stack.end()) {
+            if (m_around_stack.find(ident) != m_around_stack.end())
+            {
                 stats_before = m_around_stack[ident];
                 m_around_stack.erase(ident);
             }
@@ -925,7 +926,8 @@ int advice_chrome_tracing_t::after(const char *module,
             prev_ts = stats_before.ts;
 
             /* if collecting statistics, also collect at the End event */
-            if (m_cpu_mem_usage_enable == 1) {
+            if (m_cpu_mem_usage_enable == 1)
+            {
                 cpu_start = stats_before.cpu;
                 wall_start = stats_before.wall;
                 mem_start = stats_before.mem;
@@ -933,7 +935,8 @@ int advice_chrome_tracing_t::after(const char *module,
 
             }
 
-            else if (m_compact_event_enable == 1) {
+            else if (m_compact_event_enable == 1)
+            {
                 prev_ts = stats_before.ts;
             }
 

--- a/src/c/runtime/advice_chrome_tracing.cpp
+++ b/src/c/runtime/advice_chrome_tracing.cpp
@@ -840,7 +840,6 @@ int advice_chrome_tracing_t::after(const char *module,
                                    const char *flow,
                                    const char *pcut)
 {
-    
     double cpu_usage, wall_time, duration;
     long mem_usage;
     if (std::string("around") == pcut)
@@ -904,7 +903,7 @@ int advice_chrome_tracing_t::after(const char *module,
         m_statistics stats_before = {}; /* the statistics collected from a before event*/
         if (std::string("around") == pcut && (m_cpu_mem_usage_enable == 1 ||
                                               m_compact_event_enable == 1))
-        {            
+        {
             jtemp = json_object_get(event, "name");
             std::string my_name = json_string_value(jtemp);
             jtemp = json_object_get(event, "pid");

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -65,6 +65,33 @@ private:
     pthread_mutex_t m_after_counter_mutex;
     pthread_mutex_t m_mutex;
     std::map<std::string, std::string> m_perfflow_options;
+    
+    struct m_statistics {
+        double cpu;
+        double wall;
+        long mem;
+        double ts;
+    };
+
+    struct m_identifier {
+        std::string name;
+        int pid;
+        int tid;
+
+        friend bool operator==(const m_identifier& l, const m_identifier& r) {
+            std::tuple<std::string, int, int> lval = std::make_tuple(l.name, l.pid, l.tid);
+            std::tuple<std::string, int, int> rval = std::make_tuple(r.name, r.pid, r.tid);
+            return (lval == rval);
+        };
+
+        friend bool operator<(const m_identifier& l, const m_identifier &r) {
+            std::tuple<std::string, int, int> lval = std::make_tuple(l.name, l.pid, l.tid);
+            std::tuple<std::string, int, int> rval = std::make_tuple(r.name, r.pid, r.tid);
+            return (lval < rval);
+        };
+    };
+
+    std::map<m_identifier, m_statistics> m_around_stack;
 };
 
 /*

--- a/src/c/runtime/advice_chrome_tracing.hpp
+++ b/src/c/runtime/advice_chrome_tracing.hpp
@@ -65,7 +65,8 @@ private:
     pthread_mutex_t m_after_counter_mutex;
     pthread_mutex_t m_mutex;
     std::map<std::string, std::string> m_perfflow_options;
-    
+   
+    /* the collected statistics from running a trace */
     struct m_statistics {
         double cpu;
         double wall;
@@ -73,11 +74,13 @@ private:
         double ts;
     };
 
+    /* a node is identified by the process id and thread id */
     struct m_identifier {
         std::string name;
         int pid;
         int tid;
 
+	/* check if a node is the same, or if a node should be ordered before */
         friend bool operator==(const m_identifier& l, const m_identifier& r) {
             std::tuple<std::string, int, int> lval = std::make_tuple(l.name, l.pid, l.tid);
             std::tuple<std::string, int, int> rval = std::make_tuple(r.name, r.pid, r.tid);
@@ -91,6 +94,7 @@ private:
         };
     };
 
+    /* a mapping of nodes to their statistics */
     std::map<m_identifier, m_statistics> m_around_stack;
 };
 


### PR DESCRIPTION
This issue resolves #159. Specifically; significant file IO file overhead was created in compact mode that resulted in an increase in time. This issue is solved in this PR by using a mapping of node identifiers to their statistics so that we can more efficiently access the nodes we need, and the statistics in them.