### PR TITLE
Fix to issue #156: multithread end events

### DIFF
--- a/src/c/weaver/weave/perfflow_weave_common.cpp
+++ b/src/c/weaver/weave/perfflow_weave_common.cpp
@@ -153,7 +153,18 @@ bool weave_ns::WeaveCommon::insertAfter(Module &m, Function &f, StringRef &a,
     for (BasicBlock &bb : f)
     {
         Instruction *inst = bb.getTerminator();
-        if (isa<ReturnInst>(inst) || isa<ResumeInst>(inst))
+        bool exitFlag = false;
+        printf("outside\n");
+        if (auto *callInst = dyn_cast<CallInst>(inst)) {
+            printf("inside first if\n");
+            if (auto *callee = callInst->getCalledFunction()) {
+                printf("inside second if, %s\n", callee->getName().str().c_str());
+                if (callee->getName() == "exit" || callee->getName() == "abort" || callee->getName() == "pthread_exit") {
+                    exitFlag = true;
+                }
+            }
+        }
+        if (isa<ReturnInst>(inst) || isa<ResumeInst>(inst) || exitFlag)
         {
             IRBuilder<> builder(inst);
             Value *v1 = builder.CreateGlobalStringPtr(m.getName(), "str");


### PR DESCRIPTION
Fixes #156, by detecting `pthread_exit` (as well as `exit` and abort` calls) in the client's source code. 