### PR TITLE
Add -fpass-plugin= to WeavePassPlugin's exported compile options

### DIFF
--- a/src/c/weaver/weave/CMakeLists.txt
+++ b/src/c/weaver/weave/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(WeavePass perfflow_parser ${JANSSON_LIB})
 
 add_library(WeavePassPlugin INTERFACE)
 target_compile_options(WeavePassPlugin INTERFACE
-    "SHELL:$<BUILD_INTERFACE:-Xclang -load -Xclang $<TARGET_FILE:WeavePass>>$<INSTALL_INTERFACE:-Xclang -load -Xclang $<TARGET_FILE:perfflowaspect::WeavePass>>"
+    "SHELL:$<BUILD_INTERFACE:-Xclang -load -Xclang $<TARGET_FILE:WeavePass> -fpass-plugin=$<TARGET_FILE:WeavePass>>$<INSTALL_INTERFACE:-Xclang -load -Xclang $<TARGET_FILE:perfflowaspect::WeavePass> -fpass-plugin=$<TARGET_FILE:perfflowaspect::WeavePass>>"
 )
 
 install(TARGETS WeavePassPlugin


### PR DESCRIPTION
The exported `perfflowaspect::WeavePassPlugin` INTERFACE target only sets `-Xclang -load -Xclang <path>`, but does not call llvmGetPassPluginInfo() to register the pass into the new-PM pipeline. Downstream consumers (e.g. GROMACS via find_package) compiled and linked cleanly, but annotated functions were silently never woven, with no error pointing at the cause.

In-tree tests (src/c/test/CMakeLists.txt) already set both flags manually, which masked this gap in the exported target.

Fixes #202 